### PR TITLE
Support link feature on launcher

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,7 +23,7 @@ type ECSCfg struct {
 	CapacityProviderStrategy CapacityProviderStrategy `yaml:"capacity_provider_strategy"`
 	LaunchType               *string                  `yaml:"launch_type"`
 	NetworkConfiguration     *NetworkConfiguration    `yaml:"network_configuration"`
-	DefaultTaskDefinition    string                   `yaml:"default_task_definition"`
+	DefaultTaskDefinitions   []string                 `yaml:"default_task_definitions"`
 	EnableExecuteCommand     *bool                    `yaml:"enable_execute_command"`
 }
 

--- a/config.go
+++ b/config.go
@@ -23,7 +23,7 @@ type ECSCfg struct {
 	CapacityProviderStrategy CapacityProviderStrategy `yaml:"capacity_provider_strategy"`
 	LaunchType               *string                  `yaml:"launch_type"`
 	NetworkConfiguration     *NetworkConfiguration    `yaml:"network_configuration"`
-	DefaultTaskDefinitions   []string                 `yaml:"default_task_definitions"`
+	DefaultTaskDefinition    string                   `yaml:"default_task_definition"`
 	EnableExecuteCommand     *bool                    `yaml:"enable_execute_command"`
 }
 
@@ -84,7 +84,8 @@ type Host struct {
 }
 
 type Link struct {
-	HostedZoneID string `yaml:"hosted_zone_id"`
+	HostedZoneID           string   `yaml:"hosted_zone_id"`
+	DefaultTaskDefinitions []string `yaml:"default_task_definitions"`
 }
 
 type Listen struct {

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -41,7 +41,12 @@ ecs:
       security_groups:
         - '{{ env "SECURITY_GROUP_1" "sg-111111" }}'
       assign_public_ip: ENABLED
-  default_task_definitions:
-    - '{{ env "DEFAULT_TASKDEF" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp" }}'
-  # another task definition for link feature
-  #  - '{{ env "DEFAULT_TASKDEF_LINK" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp-link" }}'
+  default_task_definition: '{{ env "DEFAULT_TASKDEF" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp" }}'
+
+# # enable link feature
+# link:
+#   hosted_zone_id: '{{ env "LINK_ZONE_ID" "Z00000000000000000000" }}'
+#   # overwrite ecs.default_task_definition
+#   default_task_definitions:
+#     - '{{ env "DEFAULT_TASKDEF" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp" }}'
+#     - '{{ env "DEFAULT_TASKDEF_LINK" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp-link" }}'

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -41,4 +41,7 @@ ecs:
       security_groups:
         - '{{ env "SECURITY_GROUP_1" "sg-111111" }}'
       assign_public_ip: ENABLED
-  default_task_definition: '{{ env "DEFAULT_TASKDEF" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp" }}'
+  default_task_definitions:
+    - '{{ env "DEFAULT_TASKDEF" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp" }}'
+  # another task definition for link feature
+  #  - '{{ env "DEFAULT_TASKDEF_LINK" "arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp-link" }}'

--- a/config_test.go
+++ b/config_test.go
@@ -28,9 +28,7 @@ listen:
 ecs:
   region: ap-northeast-1
   cluster: test-cluster
-  default_task_definitions:
-    - test-task-definition
-    - test-task-definition-link
+  default_task_definition: test-task-definition
   capacity_provider_strategy:
     - capacity_provider: test-strategy
       base: 1
@@ -58,6 +56,12 @@ parameters:
     env: NICK
     rule: "[0-9A-Za-z]{10}"
     required: false
+
+link:
+  hosted_zone_id: Z00000000000000000000
+  default_task_definitions:
+    - test-task-definition
+    - test-task-definition-link
 `
 
 	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
@@ -84,11 +88,8 @@ parameters:
 	if cfg.ECS.Cluster != "test-cluster" {
 		t.Error("could not parse cluster")
 	}
-	if cfg.ECS.DefaultTaskDefinitions[0] != "test-task-definition" {
-		t.Error("could not parse default_task_definitions")
-	}
-	if cfg.ECS.DefaultTaskDefinitions[1] != "test-task-definition-link" {
-		t.Error("could not parse default_task_definitions")
+	if cfg.ECS.DefaultTaskDefinition != "test-task-definition" {
+		t.Error("could not parse default_task_definition")
 	}
 	provider := cfg.ECS.CapacityProviderStrategy[0]
 	if *provider.CapacityProvider != "test-strategy" {
@@ -109,5 +110,14 @@ parameters:
 	}
 	if !*cfg.ECS.EnableExecuteCommand {
 		t.Error("could not parse enable execute command")
+	}
+	if cfg.Link.HostedZoneID != "Z00000000000000000000" {
+		t.Error("could not parse link hosted zone")
+	}
+	if cfg.Link.DefaultTaskDefinitions[0] != "test-task-definition" {
+		t.Error("could not parse link default task definitions")
+	}
+	if cfg.Link.DefaultTaskDefinitions[1] != "test-task-definition-link" {
+		t.Error("could not parse link default task definitions")
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -28,7 +28,9 @@ listen:
 ecs:
   region: ap-northeast-1
   cluster: test-cluster
-  default_task_definition: test-task-definition
+  default_task_definitions:
+    - test-task-definition
+    - test-task-definition-link
   capacity_provider_strategy:
     - capacity_provider: test-strategy
       base: 1
@@ -82,8 +84,11 @@ parameters:
 	if cfg.ECS.Cluster != "test-cluster" {
 		t.Error("could not parse cluster")
 	}
-	if cfg.ECS.DefaultTaskDefinition != "test-task-definition" {
-		t.Error("could not parse default_task_definition")
+	if cfg.ECS.DefaultTaskDefinitions[0] != "test-task-definition" {
+		t.Error("could not parse default_task_definitions")
+	}
+	if cfg.ECS.DefaultTaskDefinitions[1] != "test-task-definition-link" {
+		t.Error("could not parse default_task_definitions")
 	}
 	provider := cfg.ECS.CapacityProviderStrategy[0]
 	if *provider.CapacityProvider != "test-strategy" {

--- a/html/launcher.html
+++ b/html/launcher.html
@@ -22,16 +22,16 @@
 
 {{ if eq $i 0 }}
 
-<label for="taskdef" class="col-md-2 text-right">Task Definitions</label>
+  <label for="taskdef" class="col-md-2 text-right">Task Definitions</label>
 
 {{ else }}
 
-<div class="col-md-2"></div>
+  <div class="col-md-2"></div>
 
 {{ end }}
 
-<input type="text" name="taskdef" value="{{ $taskdef }}" id="taskdef"
-        class="col-md-5" placeholder="arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp">
+  <input type="text" name="taskdef" value="{{ $taskdef }}" id="taskdef"
+         class="col-md-5" placeholder="arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp">
   <p class="col-md-5">*Required</p>
 
 {{ end }}

--- a/html/launcher.html
+++ b/html/launcher.html
@@ -18,10 +18,23 @@
 
 {{ end }}
 
-  <label for="taskdef" class="col-md-2 text-right">Task Definition</label>
-  <input type="text" name="taskdef" value="{{ .DefaultTaskDefinition }}" id="taskdef"
-         class="col-md-5" placeholder="arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp">
+{{ range $i, $taskdef := .DefaultTaskDefinitions }}
+
+{{ if eq $i 0 }}
+
+<label for="taskdef" class="col-md-2 text-right">Task Definitions</label>
+
+{{ else }}
+
+<div class="col-md-2"></div>
+
+{{ end }}
+
+<input type="text" name="taskdef" value="{{ $taskdef }}" id="taskdef"
+        class="col-md-5" placeholder="arn:aws:ecs:ap-northeast-1:123456789012:task-definition/myapp">
   <p class="col-md-5">*Required</p>
+
+{{ end }}
 
   <p class="col-md-7"></p>
   <p class="col-md-5 text-left">

--- a/webapi.go
+++ b/webapi.go
@@ -57,8 +57,14 @@ func (api *WebApi) List(c rocket.CtxData) {
 }
 
 func (api *WebApi) Launcher(c rocket.CtxData) {
+	var taskdefs []string
+	if api.cfg.Link.DefaultTaskDefinitions != nil {
+		taskdefs = api.cfg.Link.DefaultTaskDefinitions
+	} else {
+		taskdefs = []string{api.cfg.ECS.DefaultTaskDefinition}
+	}
 	c.Render(api.cfg.HtmlDir+"/launcher.html", rocket.RenderVars{
-		"DefaultTaskDefinitions": api.cfg.ECS.DefaultTaskDefinitions,
+		"DefaultTaskDefinitions": taskdefs,
 		"Parameters":             api.cfg.Parameter,
 	})
 }

--- a/webapi.go
+++ b/webapi.go
@@ -58,8 +58,8 @@ func (api *WebApi) List(c rocket.CtxData) {
 
 func (api *WebApi) Launcher(c rocket.CtxData) {
 	c.Render(api.cfg.HtmlDir+"/launcher.html", rocket.RenderVars{
-		"DefaultTaskDefinition": api.cfg.ECS.DefaultTaskDefinition,
-		"Parameters":            api.cfg.Parameter,
+		"DefaultTaskDefinitions": api.cfg.ECS.DefaultTaskDefinitions,
+		"Parameters":             api.cfg.Parameter,
 	})
 }
 


### PR DESCRIPTION
Although mirage link feature being added in #1, the launcher page only supports launching an environment that consists of single task definition.
This PR adds link feature support as below:

- In `config.yml`, specify multiple task definitions as `link.default_task_definitions` (overwrites `ecs.default_task_definition`)
- The launcher renders input fields of the number of task definitions in `link.default_task_definitions` if it is defined
