### PR TITLE
subdomain allows path.Match() wildcard.

### DIFF
--- a/webapi.go
+++ b/webapi.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/acidlemon/rocket.v2"
 )
 
-var DNSNameRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$`)
+var DNSNameRegexpWithPattern = regexp.MustCompile(`^[a-zA-Z*?\[\]][a-zA-Z0-9-*?\[\]]{0,61}[a-zA-Z0-9*?\[\]]$`)
 
 type WebApi struct {
 	rocket.WebApp
@@ -285,8 +285,11 @@ func randomString(n int) string {
 }
 
 func validateSubdomain(s string) error {
-	if !DNSNameRegexp.MatchString(s) {
-		return errors.New("subdomain format is invalid")
+	if !DNSNameRegexpWithPattern.MatchString(s) {
+		return fmt.Errorf("subdomain includes invalid characters")
+	}
+	if _, err := path.Match(s, "x"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/webapi_test.go
+++ b/webapi_test.go
@@ -137,6 +137,10 @@ var validSubdomains = []string{
 	"AB-CD",
 	"a-z-0-9",
 	"a123456789",
+	"www*",
+	"foo[0-9]",
+	"api-?-test",
+	"*-xxx",
 	strings.Repeat("a", 63),
 }
 
@@ -147,10 +151,11 @@ var invalidSubdomains = []string{
 	"a.b",
 	"a+b",
 	"a_b",
-	"a*b",
 	"a^b",
 	"a$b",
 	"a%b",
+	"www/xxx",
+	"foo[0-9",
 	strings.Repeat("a", 64),
 }
 


### PR DESCRIPTION
Readme says,
> subdomain supports wildcard (e.g. www*,foo[0-9], api-?-test).