### PR TITLE
Add access counter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,117 @@ parameters:
 
 You can add custom parameter. "rule" option is regexp string.
 
+### API Documents
+
+#### `GET /api/list`
+
+`/api/list` returns list of running tasks.
+
+```json
+{
+    "result": [
+        {
+            "id": "arn:aws:ecs:ap-northeast-1:12345789012:task/dev/af8e7a6dad6e44d4862696002f41c2dc",
+            "short_id": "af8e7a6dad6e44d4862696002f41c2dc",
+            "subdomain": "b15",
+            "branch": "topic/b15",
+            "taskdef": "dev:756",
+            "ipaddress": "10.206.242.48",
+            "created": "0001-01-01T00:00:00Z",
+            "last_status": "PENDING",
+            "port_map": {
+                "nginx": 80
+            },
+            "env": {
+                "GIT_BRANCH": "topic/b15",
+                "SUBDOMAIN": "YjE1",
+            }
+        },
+        {
+            "id": "arn:aws:ecs:ap-northeast-1:123456789012:task/dev/d007a00bf9a0411ebbcf95291aced40f",
+            "short_id": "d007a00bf9a0411ebbcf95291aced40f",
+            "subdomain": "bench",
+            "branch": "feature/bench",
+            "taskdef": "dev:641",
+            "ipaddress": "10.206.240.60",
+            "created": "2023-03-13T00:29:08.959Z",
+            "last_status": "RUNNING",
+            "port_map": {
+                "nginx": 80
+            },
+            "env": {
+                "GIT_BRANCH": "feature/bench",
+                "SUBDOMAIN": "YmVuY2g=",
+            }
+        }
+    ]
+}
+```
+
+#### `POST /api/launch`
+
+`/api/launch` launches a new task.
+
+Parameters:
+- `subdomain`: subdomain of the task.
+- `branch`: branch name for the task.
+- `taskdef`: ECS task definition name (maybe includes revision) for the task.
+
+```json
+{
+  "status": "ok"
+}
+```
+
+#### `GET /api/logs`
+
+`/api/logs` returns logs of the task.
+
+Parameters:
+- `subdomain`: subdomain of the task.
+- `since`: RFC3339 timestamp of the first log to return.
+- `tail`: number of lines to return or `all`.
+
+```json
+{
+    "result": [
+      "2023/03/13 00:29:08 [notice] 1#1: using the \"epoll\" event method",
+      "2023/03/13 00:29:08 [notice] 1#1: nginx/1.11.10",
+    ]
+}
+```
+
+#### `POST /api/terminate`
+
+`/api/terminate` terminates the task.
+
+Parameters:
+- `subdomain`: subdomain of the task.
+- `id`: task ID of the task.
+
+`subdomain` and `id` are exclusive. If both are specified, `id` is used.
+
+```json
+{
+  "status": "ok"
+}
+```
+
+#### `GET /api/access`
+
+`/api/access` returns access counter of the task.
+
+Parameters:
+- `subdomain`: subdomain of the task.
+- `duration`: duration(seconds) of the counter. default is 86400.
+
+```json
+{
+  "result": "ok",
+  "duration": 86400,
+  "sum": 123
+}
+```
 
 ### mirage link
 

--- a/access_counter.go
+++ b/access_counter.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// accessCounter is a thread-safe counter for access
+type accessCounter struct {
+	mu    *sync.Mutex
+	unit  time.Duration
+	count map[time.Time]int64
+}
+
+// newAccessCounter returns a new access counter
+// unit is the time unit for the counter (default: time.Minute)
+func newAccessCounter(unit time.Duration) *accessCounter {
+	if unit == 0 {
+		unit = time.Minute
+	}
+	return &accessCounter{
+		mu:    new(sync.Mutex),
+		count: make(map[time.Time]int64, 2), // 2 is enough for most cases
+		unit:  unit,
+	}
+}
+
+// Add increments the access counter
+func (c *accessCounter) Add() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now().Truncate(c.unit)
+	c.count[now]++
+}
+
+// Collect returns the access count and resets the counter
+func (c *accessCounter) Collect() map[time.Time]int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r := make(map[time.Time]int64, len(c.count))
+	for k, v := range c.count {
+		r[k] = v
+		delete(c.count, k)
+	}
+	return r
+}

--- a/access_counter.go
+++ b/access_counter.go
@@ -18,11 +18,13 @@ func newAccessCounter(unit time.Duration) *accessCounter {
 	if unit == 0 {
 		unit = time.Minute
 	}
-	return &accessCounter{
+	c := &accessCounter{
 		mu:    new(sync.Mutex),
 		count: make(map[time.Time]int64, 2), // 2 is enough for most cases
 		unit:  unit,
 	}
+	c.fill()
+	return c
 }
 
 // Add increments the access counter
@@ -42,6 +44,10 @@ func (c *accessCounter) Collect() map[time.Time]int64 {
 		r[k] = v
 		delete(c.count, k)
 	}
-	c.count[time.Now().Truncate(c.unit)] = 0 // reset the counter
+	c.fill()
 	return r
+}
+
+func (c *accessCounter) fill() {
+	c.count[time.Now().Truncate(c.unit)] = 0
 }

--- a/access_counter.go
+++ b/access_counter.go
@@ -42,5 +42,6 @@ func (c *accessCounter) Collect() map[time.Time]int64 {
 		r[k] = v
 		delete(c.count, k)
 	}
+	c.count[time.Now().Truncate(c.unit)] = 0 // reset the counter
 	return r
 }

--- a/access_counter_test.go
+++ b/access_counter_test.go
@@ -28,7 +28,9 @@ func TestAccessCounter(t *testing.T) {
 		t.Errorf("could not collect access count %#v", r)
 	}
 	r2 := c.Collect()
-	if len(r2) != 0 {
-		t.Errorf("counter should be empty %#v", r2)
+	for _, v := range r2 {
+		if v != 0 {
+			t.Errorf("counter should be zero %#v", r2)
+		}
 	}
 }

--- a/access_counter_test.go
+++ b/access_counter_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAccessCounter(t *testing.T) {
+	c := newAccessCounter(time.Second)
+	start := time.Now().Truncate(time.Second)
+	c.Add()
+	c.Add()
+	c.Add()
+	time.Sleep(time.Second)
+	c.Add()
+	c.Add()
+	c.Add()
+	c.Add()
+	c.Add()
+	r := c.Collect()
+	if len(r) != 2 {
+		t.Errorf("could not collect access count %#v", r)
+	}
+	if r[start] != 3 {
+		t.Errorf("could not collect access count %#v", r)
+	}
+	if r[start.Add(time.Second)] != 5 {
+		t.Errorf("could not collect access count %#v", r)
+	}
+	r2 := c.Collect()
+	if len(r2) != 0 {
+		t.Errorf("counter should be empty %#v", r2)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	config "github.com/kayac/go-config"
 )
@@ -17,6 +19,7 @@ type Config struct {
 	Link      Link      `yaml:"link"`
 
 	localMode bool
+	session   *session.Session
 }
 
 type ECSCfg struct {
@@ -138,6 +141,10 @@ func NewConfig(path string) *Config {
 			v.Regexp = *paramRegex
 		}
 	}
+
+	cfg.session = session.Must(session.NewSession(
+		&aws.Config{Region: aws.String(cfg.ECS.Region)},
+	))
 
 	return cfg
 }

--- a/ecs.go
+++ b/ecs.go
@@ -11,7 +11,6 @@ import (
 
 	ttlcache "github.com/ReneKroon/ttlcache/v2"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/pkg/errors"
@@ -67,14 +66,10 @@ func NewECS(cfg *Config) ECSInterface {
 		return NewECSLocal(cfg)
 	}
 
-	sess := session.Must(session.NewSession(
-		&aws.Config{Region: aws.String(cfg.ECS.Region)},
-	))
-
 	ecs := &ECS{
 		cfg:            cfg,
-		ECS:            ecs.New(sess),
-		CloudWatchLogs: cloudwatchlogs.New(sess),
+		ECS:            ecs.New(cfg.session),
+		CloudWatchLogs: cloudwatchlogs.New(cfg.session),
 		proxyCh:        make(chan *proxyControl, 10),
 	}
 	return ecs

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/methane/rproxy v0.0.0-20130309122237-aafd1c66433b
 	github.com/naoina/denco v0.0.0-20180930074809-8475105a6b4c // indirect
 	github.com/pkg/errors v0.9.1
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/acidlemon/rocket.v2 v2.0.0-20150507072438-2f36fbec9709
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/mirage.go
+++ b/mirage.go
@@ -138,7 +138,7 @@ func (m *Mirage) GetAccessCount(subdomain string, duration time.Duration) (int64
 		EndTime:   aws.Time(time.Now()),
 		MetricDataQueries: []*cloudwatch.MetricDataQuery{
 			{
-				Id: aws.String("RequestCount"),
+				Id: aws.String("request_count"),
 				MetricStat: &cloudwatch.MetricStat{
 					Metric: &cloudwatch.Metric{
 						Dimensions: []*cloudwatch.Dimension{

--- a/mirage.go
+++ b/mirage.go
@@ -22,8 +22,8 @@ type Mirage struct {
 	WebApi       *WebApi
 	ReverseProxy *ReverseProxy
 	ECS          ECSInterface
-	CloudWatch   *cloudwatch.CloudWatch
 	Route53      *Route53
+	CloudWatch   *cloudwatch.CloudWatch
 }
 
 func Setup(cfg *Config) {
@@ -33,6 +33,7 @@ func Setup(cfg *Config) {
 		ReverseProxy: NewReverseProxy(cfg),
 		ECS:          NewECS(cfg),
 		Route53:      NewRoute53(cfg),
+		CloudWatch:   cloudwatch.New(cfg.session),
 	}
 
 	app = m

--- a/webapi.go
+++ b/webapi.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	"path"
@@ -37,6 +38,7 @@ func NewWebApi(cfg *Config) *WebApi {
 	app.AddRoute("/api/launch", app.ApiLaunch, view)
 	app.AddRoute("/api/logs", app.ApiLogs, view)
 	app.AddRoute("/api/terminate", app.ApiTerminate, view)
+	app.AddRoute("/api/access", app.ApiAccess, view)
 
 	app.BuildRouter()
 
@@ -126,6 +128,11 @@ func (api *WebApi) ApiTerminate(c rocket.CtxData) {
 	c.RenderJSON(result)
 }
 
+func (api *WebApi) ApiAccess(c rocket.CtxData) {
+	result := api.accessCounter(c)
+	c.RenderJSON(result)
+}
+
 func (api *WebApi) launch(c rocket.CtxData) rocket.RenderVars {
 	if c.Req().Method != "POST" {
 		c.Res().StatusCode = http.StatusMethodNotAllowed
@@ -159,6 +166,7 @@ func (api *WebApi) launch(c rocket.CtxData) rocket.RenderVars {
 	} else {
 		err := app.ECS.Launch(subdomain, parameter, taskdefs...)
 		if err != nil {
+			log.Println("[error] launch failed: ", err)
 			status = err.Error()
 		}
 	}
@@ -241,7 +249,7 @@ func (api *WebApi) terminate(c rocket.CtxData) rocket.RenderVars {
 			status = err.Error()
 		}
 	} else {
-		status = fmt.Sprintf("parameter required: id")
+		status = "parameter required: id"
 	}
 
 	result := rocket.RenderVars{
@@ -249,6 +257,29 @@ func (api *WebApi) terminate(c rocket.CtxData) rocket.RenderVars {
 	}
 
 	return result
+}
+
+func (api *WebApi) accessCounter(c rocket.CtxData) rocket.RenderVars {
+	subdomain, _ := c.ParamSingle("subdomain")
+	duration, _ := c.ParamSingle("duration")
+	durationInt, _ := strconv.ParseInt(duration, 10, 64)
+	if durationInt == 0 {
+		durationInt = 86400 // 24 hours
+	}
+	d := time.Duration(durationInt) * time.Second
+	sum, err := app.GetAccessCount(subdomain, d)
+	if err != nil {
+		log.Println("[error] access counter failed: ", err)
+		return rocket.RenderVars{
+			"result": err.Error(),
+		}
+	}
+	return rocket.RenderVars{
+		"result":    "ok",
+		"subdomain": subdomain,
+		"duration":  durationInt,
+		"sum":       sum,
+	}
 }
 
 func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {

--- a/webapi.go
+++ b/webapi.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
 	"path"
 	"regexp"
@@ -269,16 +268,16 @@ func (api *WebApi) accessCounter(c rocket.CtxData) rocket.RenderVars {
 	d := time.Duration(durationInt) * time.Second
 	sum, err := app.GetAccessCount(subdomain, d)
 	if err != nil {
+		c.Res().StatusCode = http.StatusInternalServerError
 		log.Println("[error] access counter failed: ", err)
 		return rocket.RenderVars{
 			"result": err.Error(),
 		}
 	}
 	return rocket.RenderVars{
-		"result":    "ok",
-		"subdomain": subdomain,
-		"duration":  durationInt,
-		"sum":       sum,
+		"result":   "ok",
+		"duration": durationInt,
+		"sum":      sum,
 	}
 }
 
@@ -303,16 +302,6 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
 	}
 
 	return parameter, nil
-}
-
-const rsLetters = "0123456789abcdef"
-
-func randomString(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = rsLetters[rand.Intn(len(rsLetters))]
-	}
-	return string(b)
 }
 
 func validateSubdomain(s string) error {


### PR DESCRIPTION
Add a feature to track the number of accesses for each subdomain.

Mirage-ECS will increment the access count for each subdomain when proxying HTTP requests. Every 60 seconds, Mirage-ECS will then submit these metrics to CloudWatch.

The API endpoint /api/access returns the total number of access counts for a specified subdomain by aggregating the data from CloudWatch metrics over a specified time period.