### PR TITLE
Add local mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	Parameter Paramters `yaml:"parameters"`
 	ECS       ECSCfg    `yaml:"ecs"`
 	Link      Link      `yaml:"link"`
+
+	localMode bool
 }
 
 type ECSCfg struct {

--- a/ecs.go
+++ b/ecs.go
@@ -61,7 +61,12 @@ type ECS struct {
 	proxyCh chan *proxyControl
 }
 
-func NewECS(cfg *Config) *ECS {
+func NewECS(cfg *Config) ECSInterface {
+	if cfg.localMode {
+		log.Println("[info] running in local mode with mock ECS.")
+		return NewECSLocal(cfg)
+	}
+
 	sess := session.Must(session.NewSession(
 		&aws.Config{Region: aws.String(cfg.ECS.Region)},
 	))

--- a/ecs.go
+++ b/ecs.go
@@ -44,6 +44,15 @@ const (
 	statusStopped = "STOPPED"
 )
 
+type ECSInterface interface {
+	Run()
+	Launch(subdomain string, option map[string]string, taskdefs ...string) error
+	Logs(subdomain string, since time.Time, tail int) ([]string, error)
+	Terminate(subdomain string) error
+	TerminateBySubdomain(subdomain string) error
+	List(status string) ([]Information, error)
+}
+
 type ECS struct {
 	cfg            *Config
 	ECS            *ecs.ECS
@@ -127,7 +136,7 @@ SYNC:
 	}
 }
 
-func (d *ECS) LaunchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyValuePair) error {
+func (d *ECS) launchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyValuePair) error {
 	log.Printf("[info] launching task subdomain:%s taskdef:%s", subdomain, taskdef)
 	tdOut, err := d.ECS.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskdef),
@@ -181,7 +190,7 @@ func (d *ECS) LaunchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyV
 }
 
 func (d *ECS) Launch(subdomain string, option map[string]string, taskdefs ...string) error {
-	if infos, err := d.Find(subdomain); err != nil {
+	if infos, err := d.find(subdomain); err != nil {
 		return errors.Wrapf(err, "failed to get subdomain %s", subdomain)
 	} else if len(infos) > 0 {
 		log.Printf("[info] subdomain %s is already running %d tasks. Terminating...", subdomain, len(infos))
@@ -213,14 +222,14 @@ func (d *ECS) Launch(subdomain string, option map[string]string, taskdefs ...str
 	for _, taskdef := range taskdefs {
 		taskdef := taskdef
 		eg.Go(func() error {
-			return d.LaunchTask(subdomain, taskdef, dockerEnv)
+			return d.launchTask(subdomain, taskdef, dockerEnv)
 		})
 	}
 	return eg.Wait()
 }
 
 func (d *ECS) Logs(subdomain string, since time.Time, tail int) ([]string, error) {
-	infos, err := d.Find(subdomain)
+	infos, err := d.find(subdomain)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +325,7 @@ func (d *ECS) Terminate(taskArn string) error {
 }
 
 func (d *ECS) TerminateBySubdomain(subdomain string) error {
-	infos, err := d.Find(subdomain)
+	infos, err := d.find(subdomain)
 	if err != nil {
 		return err
 	}
@@ -337,7 +346,7 @@ func (d *ECS) TerminateBySubdomain(subdomain string) error {
 	return eg.Wait()
 }
 
-func (d *ECS) Find(subdomain string) ([]Information, error) {
+func (d *ECS) find(subdomain string) ([]Information, error) {
 	var results []Information
 
 	infos, err := d.List(statusRunning)

--- a/local.go
+++ b/local.go
@@ -1,0 +1,52 @@
+package main
+
+import "time"
+
+/*
+type ECSInterface interface {
+	Run()
+	Launch(subdomain string, option map[string]string, taskdefs ...string) error
+	Logs(subdomain string, since time.Time, tail int) ([]string, error)
+	Terminate(subdomain string) error
+	TerminateBySubdomain(subdomain string) error
+	List(status string) ([]Information, error)
+}
+*/
+
+type ECSLocal struct {
+	// ECSLocal is a local mock ECS implementation for Mirage.
+}
+
+func NewECSLocal(cfg *Config) *ECSLocal {
+	// NewECSLocal returns a new ECSLocal instance.
+	return &ECSLocal{}
+}
+
+func (ecs *ECSLocal) Run() {
+	// Run starts the ECSLocal instance.
+}
+
+func (ecs *ECSLocal) List(status string) ([]Information, error) {
+	// List returns a list of ECSInfo.
+	return []Information{}, nil
+}
+
+func (ecs *ECSLocal) Launch(subdomain string, option map[string]string, taskdefs ...string) error {
+	// Launch launches a new ECS task.
+	return nil
+}
+
+func (ecs *ECSLocal) Logs(subdomain string, since time.Time, tail int) ([]string, error) {
+	// Logs returns logs of the specified subdomain.
+	return []string{}, nil
+}
+
+func (ecs *ECSLocal) Terminate(subdomain string) error {
+	// Terminate terminates the specified subdomain.
+	return nil
+}
+
+func (ecs *ECSLocal) TerminateBySubdomain(subdomain string) error {
+	// TerminateBySubdomain terminates the specified subdomain.
+	return nil
+}

--- a/local.go
+++ b/local.go
@@ -1,25 +1,32 @@
 package main
 
-import "time"
-
-/*
-type ECSInterface interface {
-	Run()
-	Launch(subdomain string, option map[string]string, taskdefs ...string) error
-	Logs(subdomain string, since time.Time, tail int) ([]string, error)
-	Terminate(subdomain string) error
-	TerminateBySubdomain(subdomain string) error
-	List(status string) ([]Information, error)
-}
-*/
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
 
 type ECSLocal struct {
 	// ECSLocal is a local mock ECS implementation for Mirage.
+	Informations map[string]Information
+
+	stopServers map[string]func()
 }
 
 func NewECSLocal(cfg *Config) *ECSLocal {
 	// NewECSLocal returns a new ECSLocal instance.
-	return &ECSLocal{}
+	return &ECSLocal{
+		Informations: map[string]Information{},
+		stopServers:  map[string]func(){},
+	}
 }
 
 func (ecs *ECSLocal) Run() {
@@ -27,26 +34,89 @@ func (ecs *ECSLocal) Run() {
 }
 
 func (ecs *ECSLocal) List(status string) ([]Information, error) {
-	// List returns a list of ECSInfo.
-	return []Information{}, nil
+	infos := make([]Information, 0, len(ecs.Informations))
+	for _, info := range ecs.Informations {
+		infos = append(infos, info)
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].Created.After(infos[j].Created)
+	})
+	return infos, nil
 }
 
 func (ecs *ECSLocal) Launch(subdomain string, option map[string]string, taskdefs ...string) error {
-	// Launch launches a new ECS task.
+	if info, ok := ecs.Informations[subdomain]; ok {
+		return fmt.Errorf("subdomain %s is already used by %s", subdomain, info.ID)
+	}
+	id := generateRandomHexID(32)
+	env := map[string]string{}
+	for k, v := range option {
+		env[strings.ToUpper(k)] = v
+	}
+	log.Printf("[info] Launching a new mock task: subdomain=%s, taskdef=%s, id=%s", subdomain, taskdefs[0], id)
+	port, stopServer := runMockServer("Hello, Mirage! subdomain: " + subdomain + "")
+	ecs.Informations[subdomain] = Information{
+		ID:         "arn:aws:ecs:ap-northeast-1:123456789012:task/mirage/" + id,
+		ShortID:    id,
+		SubDomain:  subdomain,
+		GitBranch:  option["branch"],
+		TaskDef:    taskdefs[0],
+		IPAddress:  "127.0.0.1",
+		Created:    time.Now().UTC(),
+		LastStatus: "RUNNING",
+		PortMap: map[string]int{
+			"httpd": port,
+		},
+		Env: env,
+	}
+	ecs.stopServers[id] = stopServer
+	app.ReverseProxy.AddSubdomain(subdomain, "127.0.0.1", port)
 	return nil
 }
 
 func (ecs *ECSLocal) Logs(subdomain string, since time.Time, tail int) ([]string, error) {
 	// Logs returns logs of the specified subdomain.
-	return []string{}, nil
+	return []string{"Sorry. mock server logs are empty."}, nil
 }
 
-func (ecs *ECSLocal) Terminate(subdomain string) error {
-	// Terminate terminates the specified subdomain.
+func (ecs *ECSLocal) Terminate(id string) error {
+	for _, info := range ecs.Informations {
+		if info.ID == id {
+			return ecs.TerminateBySubdomain(info.SubDomain)
+		}
+	}
 	return nil
 }
 
 func (ecs *ECSLocal) TerminateBySubdomain(subdomain string) error {
-	// TerminateBySubdomain terminates the specified subdomain.
+	log.Printf("[info] Terminating a mock task: subdomain=%s", subdomain)
+	if info, ok := ecs.Informations[subdomain]; ok {
+		stopServer := ecs.stopServers[info.ShortID]
+		if stopServer != nil {
+			stopServer()
+		}
+		app.ReverseProxy.RemoveSubdomain(info.SubDomain)
+		delete(ecs.Informations, subdomain)
+	}
 	return nil
+}
+
+func generateRandomHexID(length int) string {
+	idBytes := make([]byte, length/2)
+	if _, err := rand.Read(idBytes); err != nil {
+		panic(err)
+	}
+	id := hex.EncodeToString(idBytes)
+	return id
+}
+
+// run mock http server on ephemeral port at localhost, returns the port number and a function to stop the server
+func runMockServer(content string) (int, func()) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, content)
+	}))
+	log.Println("[info] mock server is running at", ts.URL)
+	u, _ := url.Parse(ts.URL)
+	port, _ := strconv.Atoi(u.Port())
+	return port, ts.Close
 }

--- a/main.go
+++ b/main.go
@@ -24,10 +24,11 @@ func init() {
 
 func main() {
 	confFile := flag.String("conf", "config.yml", "specify config file")
-	var showVersion, showConfig bool
+	var showVersion, showConfig, localMode bool
 	flag.BoolVar(&showVersion, "version", false, "show version")
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	flag.BoolVar(&showConfig, "x", false, "show config")
+	flag.BoolVar(&localMode, "local", false, "local mode (for development)")
 	logLevel := flag.String("log-level", "info", "log level (trace, debug, info, warn, error)")
 	flag.VisitAll(overrideWithEnv)
 	flag.Parse()
@@ -52,6 +53,7 @@ func main() {
 		pp.Print(cfg)
 		fmt.Println("") // add linebreak
 	}
+	cfg.localMode = localMode
 	Setup(cfg)
 	Run()
 }

--- a/mirage.go
+++ b/mirage.go
@@ -15,7 +15,7 @@ type Mirage struct {
 	Config       *Config
 	WebApi       *WebApi
 	ReverseProxy *ReverseProxy
-	ECS          *ECS
+	ECS          ECSInterface
 	Route53      *Route53
 }
 

--- a/webapi.go
+++ b/webapi.go
@@ -256,7 +256,7 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
 
 	for _, v := range api.cfg.Parameter {
 		param, _ := c.ParamSingle(v.Name)
-		if param == "" && v.Required == true {
+		if param == "" && v.Required {
 			return nil, fmt.Errorf("lack require parameter: %s", v.Name)
 		} else if param == "" {
 			continue


### PR DESCRIPTION
This PR introduces a new feature for debugging, namely, the local mode.

With the `-local` flag, mirage-ecs now has the capability to handle ECS tasks as local mock HTTP servers instead of actual ECS tasks on AWS.

Tasks on local mode are in memory. So these tasks are vanished on mirage-ecs process is exited.