### PR TITLE
Loading config from s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ mirage-ecs can be configured by a config file.
 
 Write a YAML file, and specify the file by the `-conf` CLI option or the `MIRAGE_CONF` environment variable.
 
+mirage-ecs can load config file from S3 and local file. To load config file from S3, specify the S3 URL (e.g. `s3://example-bucket/config.yaml`) to the `MIRAGE_CONF` environment variable.
+
+```console
+
 The default configuration is same as below.
 
 ```yaml

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 )
 
 func main() {
-	confFile := flag.String("conf", "", "specify config file")
+	confFile := flag.String("conf", "", "specify config file or S3 URL")
 	domain := flag.String("domain", ".local", "reverse proxy suffix")
 	var showVersion, showConfig, localMode bool
 	flag.BoolVar(&showVersion, "version", false, "show version")


### PR DESCRIPTION
This pull request adds the ability to load configuration files from an S3 bucket in addition to a local file.

Users can specify the S3 URL to the MIRAGE_CONF environment variable.
