### PR TITLE
Add default values.

### DIFF
--- a/config.go
+++ b/config.go
@@ -170,15 +170,21 @@ type Parameter struct {
 type Parameters []*Parameter
 
 type ConfigParams struct {
-	Path      string
-	Domain    string
-	LocalMode bool
+	Path        string
+	Domain      string
+	LocalMode   bool
+	DefaultPort int
 }
+
+const DefaultPort = 80
 
 func NewConfig(p *ConfigParams) (*Config, error) {
 	domain := p.Domain
 	if !strings.HasPrefix(domain, ".") {
 		domain = "." + domain
+	}
+	if p.DefaultPort == 0 {
+		p.DefaultPort = DefaultPort
 	}
 	// default config
 	cfg := &Config{
@@ -189,7 +195,7 @@ func NewConfig(p *ConfigParams) (*Config, error) {
 		Listen: Listen{
 			ForeignAddress: "0.0.0.0",
 			HTTP: []PortMap{
-				{ListenPort: 80, TargetPort: 80},
+				{ListenPort: p.DefaultPort, TargetPort: p.DefaultPort},
 			},
 			HTTPS: nil,
 		},

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ var DefaultParameter = &Parameter{
 	Env:      "GIT_BRANCH",
 	Rule:     "",
 	Required: true,
+	Default:  "",
 }
 
 type Config struct {
@@ -163,6 +164,7 @@ type Parameter struct {
 	Rule     string        `yaml:"rule"`
 	Required bool          `yaml:"required"`
 	Regexp   regexp.Regexp `yaml:"-"`
+	Default  string        `yaml:"default"`
 }
 
 type Parameters []*Parameter

--- a/html/launcher.html
+++ b/html/launcher.html
@@ -12,7 +12,7 @@
 {{ range $param := .Parameters }}
 
   <label for="{{ $param.Name }}" class="col-md-2 text-right">{{ $param.Name }} </label>
-  <input type="text" name="{{ $param.Name }}" value="" id="{{ $param.Name }}"
+  <input type="text" name="{{ $param.Name }}" value="{{ $param.Default }}" id="{{ $param.Name }}"
          class="col-md-5" placeholder="your {{ $param.Name }}" />
   <p class="col-md-5">{{ if $param.Required }}*Required {{ else}} (optional) {{ end }}</p>
 
@@ -44,4 +44,3 @@
 </div>
 
 {{ template "footer" }}
-

--- a/main.go
+++ b/main.go
@@ -20,10 +20,12 @@ func main() {
 	confFile := flag.String("conf", "", "specify config file or S3 URL")
 	domain := flag.String("domain", ".local", "reverse proxy suffix")
 	var showVersion, showConfig, localMode bool
+	var defaultPort int
 	flag.BoolVar(&showVersion, "version", false, "show version")
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	flag.BoolVar(&showConfig, "x", false, "show config")
 	flag.BoolVar(&localMode, "local", false, "local mode (for development)")
+	flag.IntVar(&defaultPort, "default-port", 80, "default port number")
 	logLevel := flag.String("log-level", "info", "log level (trace, debug, info, warn, error)")
 	flag.VisitAll(overrideWithEnv)
 	flag.Parse()
@@ -43,9 +45,10 @@ func main() {
 	log.Printf("[debug] setting log level: %s", *logLevel)
 
 	cfg, err := NewConfig(&ConfigParams{
-		Path:      *confFile,
-		LocalMode: localMode,
-		Domain:    *domain,
+		Path:        *confFile,
+		LocalMode:   localMode,
+		Domain:      *domain,
+		DefaultPort: defaultPort,
 	})
 	if err != nil {
 		log.Fatalf("[error] %s", err)

--- a/mirage.go
+++ b/mirage.go
@@ -49,7 +49,7 @@ func Run() {
 			laddr := fmt.Sprintf("%s:%d", app.Config.Listen.ForeignAddress, port)
 			listener, err := net.Listen("tcp", laddr)
 			if err != nil {
-				log.Printf("[error] cannot listen %s", laddr)
+				log.Printf("[error] cannot listen %s: %s", laddr, err)
 				return
 			}
 

--- a/webapi.go
+++ b/webapi.go
@@ -286,6 +286,9 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
 
 	for _, v := range api.cfg.Parameter {
 		param, _ := c.ParamSingle(v.Name)
+		if param == "" && v.Default != "" {
+			param = v.Default
+		}
 		if param == "" && v.Required {
 			return nil, fmt.Errorf("lack require parameter: %s", v.Name)
 		} else if param == "" {


### PR DESCRIPTION
- [Add default value of launch parameters.](https://github.com/acidlemon/mirage-ecs/commit/fa9a871855ac2ff2d0ce8bb1082ca02d1e5c56ea)
  Enables to fill default values into HTML form elements.
- [add -default-port flag](https://github.com/acidlemon/mirage-ecs/commit/c73c2caaca4e5197cc3915e001d8c41eea90d746) 
  Set a default port number by CLI option.