### PR TITLE
want to resolve on a first-come, first-served basis when subdomains conflict.

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -101,6 +101,9 @@ SYNC:
 			log.Println("[warn]", err)
 			continue
 		}
+		sort.SliceStable(running, func(i, j int) bool {
+			return running[i].Created.Before(running[j].Created)
+		})
 		available := make(map[string]bool)
 		for _, info := range running {
 			log.Println("[debug] ruuning task", *info.task.TaskArn)


### PR DESCRIPTION

When `*-develop` and `*-hoge-develop` are registered, in the current specification the match results are out of order and unstable.

Therefore, if conflicting patterns like this are registered, I would like to modify it so that the one that was started first is prioritized and matched.