### PR TITLE
Add ECS tags to tasks  and`exclude_tags` parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Parameters:
 - `subdomain`: subdomain of the task. (required)
 - `taskdef`: ECS task definition name (maybe includes revision) for the task. (required)
 - extra parameters: Additional parameters for the task. (optional, defined in config file `parameters` section)
+  - `branch`: branch is appended to extra parameters automatically.
 
 ```json
 {

--- a/ecs.go
+++ b/ecs.go
@@ -31,6 +31,7 @@ type Information struct {
 	PortMap    map[string]int    `json:"port_map"`
 	Env        map[string]string `json:"env"`
 
+	tags []*ecs.Tag
 	task *ecs.Task
 }
 
@@ -450,6 +451,7 @@ func (d *ECS) List(desiredStatus string) ([]Information, error) {
 				IPAddress:  getIPV4AddressFromTask(task),
 				LastStatus: *task.LastStatus,
 				Env:        getEnvironmentsFromTask(task),
+				tags:       task.Tags,
 				task:       task,
 			}
 			if portMap, err := d.portMapInTask(task); err != nil {

--- a/ecs.go
+++ b/ecs.go
@@ -34,6 +34,65 @@ type Information struct {
 	task *ecs.Task
 }
 
+type TaskParameter map[string]string
+
+func (p TaskParameter) ToECSKeyValuePairs(subdomain string, configParams Parameters) []*ecs.KeyValuePair {
+	kvp := make([]*ecs.KeyValuePair, 0, len(p)+1)
+	kvp = append(kvp, &ecs.KeyValuePair{
+		Name:  aws.String(strings.ToUpper(TagSubdomain)),
+		Value: aws.String(encodeTagValue(subdomain)),
+	})
+	for _, v := range configParams {
+		v := v
+		if p[v.Name] == "" {
+			continue
+		}
+		kvp = append(kvp, &ecs.KeyValuePair{
+			Name:  aws.String(v.Env),
+			Value: aws.String(p[v.Name]),
+		})
+	}
+	return kvp
+}
+
+func (p TaskParameter) ToECSTags(subdomain string, configParams Parameters) []*ecs.Tag {
+	tags := make([]*ecs.Tag, 0, len(p)+2)
+	tags = append(tags,
+		&ecs.Tag{
+			Key:   aws.String(TagSubdomain),
+			Value: aws.String(encodeTagValue(subdomain)),
+		},
+		&ecs.Tag{
+			Key:   aws.String(TagManagedBy),
+			Value: aws.String(TagValueMirage),
+		},
+	)
+	for _, v := range configParams {
+		v := v
+		if p[v.Name] == "" {
+			continue
+		}
+		tags = append(tags, &ecs.Tag{
+			Key:   aws.String(v.Name),
+			Value: aws.String(p[v.Name]),
+		})
+	}
+	return tags
+}
+
+func (p TaskParameter) ToEnv(subdomain string, configParams Parameters) map[string]string {
+	env := make(map[string]string, len(p)+1)
+	env[strings.ToUpper(TagSubdomain)] = encodeTagValue(subdomain)
+	for _, v := range configParams {
+		v := v
+		if p[v.Name] == "" {
+			continue
+		}
+		env[strings.ToUpper(v.Env)] = p[v.Name]
+	}
+	return env
+}
+
 const (
 	TagManagedBy   = "ManagedBy"
 	TagSubdomain   = "Subdomain"
@@ -45,7 +104,7 @@ const (
 
 type ECSInterface interface {
 	Run()
-	Launch(subdomain string, option map[string]string, taskdefs ...string) error
+	Launch(subdomain string, param TaskParameter, taskdefs ...string) error
 	Logs(subdomain string, since time.Time, tail int) ([]string, error)
 	Terminate(subdomain string) error
 	TerminateBySubdomain(subdomain string) error
@@ -139,7 +198,7 @@ SYNC:
 	}
 }
 
-func (d *ECS) launchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyValuePair) error {
+func (d *ECS) launchTask(subdomain string, taskdef string, option TaskParameter) error {
 	log.Printf("[info] launching task subdomain:%s taskdef:%s", subdomain, taskdef)
 	tdOut, err := d.ECS.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskdef),
@@ -150,18 +209,21 @@ func (d *ECS) launchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyV
 
 	// override envs for each container in taskdef
 	ov := &ecs.TaskOverride{}
+	env := option.ToECSKeyValuePairs(subdomain, d.cfg.Parameter)
+
 	for _, c := range tdOut.TaskDefinition.ContainerDefinitions {
 		name := *c.Name
 		ov.ContainerOverrides = append(
 			ov.ContainerOverrides,
 			&ecs.ContainerOverride{
 				Name:        aws.String(name),
-				Environment: dockerEnv,
+				Environment: env,
 			},
 		)
 	}
 	log.Printf("[debug] Task Override: %s", ov)
 
+	tags := option.ToECSTags(subdomain, d.cfg.Parameter)
 	runtaskInput := &ecs.RunTaskInput{
 		CapacityProviderStrategy: d.cfg.ECS.capacityProviderStrategy,
 		Cluster:                  aws.String(d.cfg.ECS.Cluster),
@@ -170,11 +232,8 @@ func (d *ECS) launchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyV
 		LaunchType:               d.cfg.ECS.LaunchType,
 		Overrides:                ov,
 		Count:                    aws.Int64(1),
-		Tags: []*ecs.Tag{
-			{Key: aws.String(TagSubdomain), Value: aws.String(encodeTagValue(subdomain))},
-			{Key: aws.String(TagManagedBy), Value: aws.String(TagValueMirage)},
-		},
-		EnableExecuteCommand: d.cfg.ECS.EnableExecuteCommand,
+		Tags:                     tags,
+		EnableExecuteCommand:     d.cfg.ECS.EnableExecuteCommand,
 	}
 	log.Printf("[debug] RunTaskInput: %s", runtaskInput)
 	out, err := d.ECS.RunTask(runtaskInput)
@@ -192,7 +251,7 @@ func (d *ECS) launchTask(subdomain string, taskdef string, dockerEnv []*ecs.KeyV
 	return nil
 }
 
-func (d *ECS) Launch(subdomain string, option map[string]string, taskdefs ...string) error {
+func (d *ECS) Launch(subdomain string, option TaskParameter, taskdefs ...string) error {
 	if infos, err := d.find(subdomain); err != nil {
 		return errors.Wrapf(err, "failed to get subdomain %s", subdomain)
 	} else if len(infos) > 0 {
@@ -204,28 +263,12 @@ func (d *ECS) Launch(subdomain string, option map[string]string, taskdefs ...str
 	}
 
 	log.Printf("[info] launching subdomain:%s taskdefs:%v", subdomain, taskdefs)
-	var dockerEnv []*ecs.KeyValuePair
-
-	for _, v := range d.cfg.Parameter {
-		v := v
-		if option[v.Name] == "" {
-			continue
-		}
-		dockerEnv = append(dockerEnv, &ecs.KeyValuePair{
-			Name:  aws.String(v.Env),
-			Value: aws.String(option[v.Name]),
-		})
-	}
-	dockerEnv = append(dockerEnv, &ecs.KeyValuePair{
-		Name:  aws.String("SUBDOMAIN"),
-		Value: aws.String(encodeTagValue(subdomain)),
-	})
 
 	var eg errgroup.Group
 	for _, taskdef := range taskdefs {
 		taskdef := taskdef
 		eg.Go(func() error {
-			return d.launchTask(subdomain, taskdef, dockerEnv)
+			return d.launchTask(subdomain, taskdef, option)
 		})
 	}
 	return eg.Wait()

--- a/ecs_test.go
+++ b/ecs_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestToECSKeyValuePairsAndTags(t *testing.T) {
+	tests := []struct {
+		name         string
+		taskParam    TaskParameter
+		configParams Parameters
+		subdomain    string
+		expectedKVP  []*ecs.KeyValuePair
+		expectedTags []*ecs.Tag
+		expectedEnv  map[string]string
+	}{
+		{
+			name: "Basic Test",
+			taskParam: TaskParameter{
+				"Param1": "Value1",
+				"Param2": "Value2",
+			},
+			configParams: Parameters{
+				&Parameter{Name: "Param1", Env: "ENV1"},
+				&Parameter{Name: "Param2", Env: "ENV2"},
+				&Parameter{Name: "Param3", Env: "ENV3"},
+			},
+			subdomain: "testsubdomain",
+			expectedKVP: []*ecs.KeyValuePair{
+				{Name: aws.String("SUBDOMAIN"), Value: aws.String("dGVzdHN1YmRvbWFpbg==")},
+				{Name: aws.String("ENV1"), Value: aws.String("Value1")},
+				{Name: aws.String("ENV2"), Value: aws.String("Value2")},
+			},
+			expectedTags: []*ecs.Tag{
+				{Key: aws.String("Subdomain"), Value: aws.String("dGVzdHN1YmRvbWFpbg==")},
+				{Key: aws.String("ManagedBy"), Value: aws.String(TagValueMirage)},
+				{Key: aws.String("Param1"), Value: aws.String("Value1")},
+				{Key: aws.String("Param2"), Value: aws.String("Value2")},
+			},
+			expectedEnv: map[string]string{
+				"SUBDOMAIN": "dGVzdHN1YmRvbWFpbg==",
+				"ENV1":      "Value1",
+				"ENV2":      "Value2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kvpResult := tt.taskParam.ToECSKeyValuePairs(tt.subdomain, tt.configParams)
+			if diff := cmp.Diff(kvpResult, tt.expectedKVP); diff != "" {
+				t.Errorf("Mismatch in KeyValuePairs (-got +want):\n%s", diff)
+			}
+			tagsResult := tt.taskParam.ToECSTags(tt.subdomain, tt.configParams)
+			if diff := cmp.Diff(tagsResult, tt.expectedTags); diff != "" {
+				t.Errorf("Mismatch in Tags (-got +want):\n%s", diff)
+			}
+			envResult := tt.taskParam.ToEnv(tt.subdomain, tt.configParams)
+			if diff := cmp.Diff(envResult, tt.expectedEnv); diff != "" {
+				t.Errorf("Mismatch in Env (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/local.go
+++ b/local.go
@@ -66,7 +66,8 @@ func (ecs *ECSLocal) Launch(subdomain string, option TaskParameter, taskdefs ...
 		PortMap: map[string]int{
 			"httpd": port,
 		},
-		Env: env,
+		Env:  env,
+		tags: option.ToECSTags(subdomain, ecs.cfg.Parameter),
 	}
 	ecs.stopServers[id] = stopServer
 	app.ReverseProxy.AddSubdomain(subdomain, "127.0.0.1", port)

--- a/webapi.go
+++ b/webapi.go
@@ -395,12 +395,12 @@ func (api *WebApi) purge(c rocket.CtxData) rocket.RenderVars {
 		for _, t := range info.tags {
 			k, v := aws.StringValue(t.Key), aws.StringValue(t.Value)
 			if ev, ok := excludeTagsMap[k]; ok && ev == v {
-				log.Printf("[info] skip exclude tag: %s=%s", k, v)
+				log.Printf("[info] skip exclude tag: %s=%s subdomain: %s", k, v, info.SubDomain)
 				continue
 			}
 		}
 		if info.Created.After(begin) {
-			log.Printf("[info] skip recent created subdomain: %s %s", info.SubDomain, info.Created.Format(time.RFC3339))
+			log.Printf("[info] skip recent created: %s subdomain: %s", info.Created.Format(time.RFC3339), info.SubDomain)
 			continue
 		}
 		tm[info.SubDomain] = struct{}{}

--- a/webapi.go
+++ b/webapi.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/samber/lo"
@@ -310,7 +311,7 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (TaskParameter, error) {
 				return nil, fmt.Errorf("parameter %s value is rule error", v.Name)
 			}
 		}
-		if len(param) > 255 {
+		if utf8.RuneCountInString(param) > 255 {
 			return nil, fmt.Errorf("parameter %s value is too long(max 255 unicode characters)", v.Name)
 		}
 		parameter[v.Name] = param

--- a/webapi.go
+++ b/webapi.go
@@ -290,8 +290,8 @@ func (api *WebApi) accessCounter(c rocket.CtxData) rocket.RenderVars {
 	}
 }
 
-func (api *WebApi) loadParameter(c rocket.CtxData) (map[string]string, error) {
-	var parameter map[string]string = make(map[string]string)
+func (api *WebApi) loadParameter(c rocket.CtxData) (TaskParameter, error) {
+	parameter := make(TaskParameter)
 
 	for _, v := range api.cfg.Parameter {
 		param, _ := c.ParamSingle(v.Name)

--- a/webapi.go
+++ b/webapi.go
@@ -310,7 +310,9 @@ func (api *WebApi) loadParameter(c rocket.CtxData) (TaskParameter, error) {
 				return nil, fmt.Errorf("parameter %s value is rule error", v.Name)
 			}
 		}
-
+		if len(param) > 255 {
+			return nil, fmt.Errorf("parameter %s value is too long(max 255 unicode characters)", v.Name)
+		}
 		parameter[v.Name] = param
 	}
 


### PR DESCRIPTION
for #28 and #29.

- Add ECS tags to launched tasks by launch parameters.
  - #28
- Add `exclude_tags` parameter to /api/purge.
  - #29

For example, add an parameter `DontPurge` in a configuration.
```yaml
parameters:
  - name: DontPurge
    env: DONT_PURGE
    rule: ""
    required: false
    default: "false"
```

When you add this parameter `DontPurge=true` to /api/launch, mirage-ecs adds a tag `Key=DontPurge,Value=true` to the task launched.

/api/purge accepts `exclude_tags` parameters. When `exclude_tags=DontPurge:true` specified, mirage-ecs ignores tasks with the tag.
