### PR TITLE
Transport timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ listen:
     - listen: 80
       target: 80
 network:
-  proxy_timeout: 300s
+  proxy_timeout: 0
 htmldir: ./html
 parameters:
   - name: branch
@@ -158,7 +158,7 @@ network:
   proxy_timeout: 30s # timeout of reverse proxy
 ```
 
-`proxy_timeout` default is 300s(5min). If `proxy_timeout` is 0, mirage-ecs does not set timeout to reverse proxy.
+`proxy_timeout` default is 0 (means no timeout). If `proxy_timeout` is not 0, mirage-ecs timeouts the request to backends after the specified duration and returns HTTP status 504 (Gateway Timeout).
 
 #### `parameters` section
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ listen:
   http:
     - listen: 80
       target: 80
+network:
+  proxy_timeout: 300s
 htmldir: ./html
 parameters:
   - name: branch
@@ -146,6 +148,17 @@ listen:
     - listen: 80 # port number of mirage-ecs webapi
       target: 80 # port number of target ECS task
 ```
+
+#### `network` section
+
+`network` section configures network settings of mirage-ecs reverse proxy.
+
+```yaml
+network:
+  proxy_timeout: 30s # timeout of reverse proxy
+```
+
+`proxy_timeout` default is 300s(5min). If `proxy_timeout` is 0, mirage-ecs does not set timeout to reverse proxy.
 
 #### `parameters` section
 

--- a/access_counter.go
+++ b/access_counter.go
@@ -10,19 +10,19 @@ import (
 type accessCount map[time.Time]int64
 
 // accessCounter is a thread-safe counter for access
-type accessCounter struct {
+type AccessCounter struct {
 	mu    *sync.Mutex
 	unit  time.Duration
 	count accessCount
 }
 
-// newAccessCounter returns a new access counter
+// NewAccessCounter returns a new access counter
 // unit is the time unit for the counter (default: time.Minute)
-func newAccessCounter(unit time.Duration) *accessCounter {
+func NewAccessCounter(unit time.Duration) *AccessCounter {
 	if unit == 0 {
 		unit = time.Minute
 	}
-	c := &accessCounter{
+	c := &AccessCounter{
 		mu:    new(sync.Mutex),
 		count: make(accessCount, 2), // 2 is enough for most cases
 		unit:  unit,
@@ -32,7 +32,7 @@ func newAccessCounter(unit time.Duration) *accessCounter {
 }
 
 // Add increments the access counter
-func (c *accessCounter) Add() {
+func (c *AccessCounter) Add() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	now := time.Now().Truncate(c.unit)
@@ -40,7 +40,7 @@ func (c *accessCounter) Add() {
 }
 
 // Collect returns the access count and resets the counter
-func (c *accessCounter) Collect() accessCount {
+func (c *AccessCounter) Collect() accessCount {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	r := make(accessCount, len(c.count))
@@ -52,6 +52,6 @@ func (c *accessCounter) Collect() accessCount {
 	return r
 }
 
-func (c *accessCounter) fill() {
+func (c *AccessCounter) fill() {
 	c.count[time.Now().Truncate(c.unit)] = 0
 }

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsv2Config "github.com/aws/aws-sdk-go-v2/config"
@@ -30,12 +31,13 @@ var DefaultParameter = &Parameter{
 }
 
 type Config struct {
-	Host      Host       `yaml:"host"`
-	Listen    Listen     `yaml:"listen"`
-	HtmlDir   string     `yaml:"htmldir"`
-	Parameter Parameters `yaml:"parameters"`
-	ECS       ECSCfg     `yaml:"ecs"`
-	Link      Link       `yaml:"link"`
+	Host         Host          `yaml:"host"`
+	Listen       Listen        `yaml:"listen"`
+	ProxyTimeout time.Duration `yaml:"proxy_timeout"`
+	HtmlDir      string        `yaml:"htmldir"`
+	Parameter    Parameters    `yaml:"parameters"`
+	ECS          ECSCfg        `yaml:"ecs"`
+	Link         Link          `yaml:"link"`
 
 	localMode bool
 	awscfg    *aws.Config

--- a/config.go
+++ b/config.go
@@ -191,7 +191,7 @@ type Network struct {
 }
 
 const DefaultPort = 80
-const DefaultProxyTimeout = 300 * time.Second
+const DefaultProxyTimeout = 0
 
 func NewConfig(ctx context.Context, p *ConfigParams) (*Config, error) {
 	domain := p.Domain

--- a/config.go
+++ b/config.go
@@ -31,13 +31,13 @@ var DefaultParameter = &Parameter{
 }
 
 type Config struct {
-	Host         Host          `yaml:"host"`
-	Listen       Listen        `yaml:"listen"`
-	ProxyTimeout time.Duration `yaml:"proxy_timeout"`
-	HtmlDir      string        `yaml:"htmldir"`
-	Parameter    Parameters    `yaml:"parameters"`
-	ECS          ECSCfg        `yaml:"ecs"`
-	Link         Link          `yaml:"link"`
+	Host      Host       `yaml:"host"`
+	Listen    Listen     `yaml:"listen"`
+	Network   Network    `yaml:"network"`
+	HtmlDir   string     `yaml:"htmldir"`
+	Parameter Parameters `yaml:"parameters"`
+	ECS       ECSCfg     `yaml:"ecs"`
+	Link      Link       `yaml:"link"`
 
 	localMode bool
 	awscfg    *aws.Config
@@ -186,7 +186,12 @@ type ConfigParams struct {
 	DefaultPort int
 }
 
+type Network struct {
+	ProxyTimeout time.Duration `yaml:"proxy_timeout"`
+}
+
 const DefaultPort = 80
+const DefaultProxyTimeout = 300 * time.Second
 
 func NewConfig(ctx context.Context, p *ConfigParams) (*Config, error) {
 	domain := p.Domain
@@ -208,6 +213,9 @@ func NewConfig(ctx context.Context, p *ConfigParams) (*Config, error) {
 				{ListenPort: p.DefaultPort, TargetPort: p.DefaultPort},
 			},
 			HTTPS: nil,
+		},
+		Network: Network{
+			ProxyTimeout: DefaultProxyTimeout,
 		},
 		HtmlDir: "./html",
 		ECS: ECSCfg{

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,5 @@
 package mirageecs
 
 var (
-	NewAccessCounter  = newAccessCounter
 	ValidateSubdomain = validateSubdomain
 )

--- a/local.go
+++ b/local.go
@@ -121,10 +121,6 @@ func generateRandomHexID(length int) string {
 // run mock http server on ephemeral port at localhost, returns the port number and a function to stop the server
 func runMockServer(content string) (int, func()) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for i := 0; i < 15; i++ {
-			time.Sleep(time.Second)
-			log.Println("[info] mock server is sleeping", i)
-		}
 		fmt.Fprintln(w, content)
 	}))
 	log.Println("[info] mock server is running at", ts.URL)

--- a/local.go
+++ b/local.go
@@ -121,6 +121,10 @@ func generateRandomHexID(length int) string {
 // run mock http server on ephemeral port at localhost, returns the port number and a function to stop the server
 func runMockServer(content string) (int, func()) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for i := 0; i < 15; i++ {
+			time.Sleep(time.Second)
+			log.Println("[info] mock server is sleeping", i)
+		}
 		fmt.Fprintln(w, content)
 	}))
 	log.Println("[info] mock server is running at", ts.URL)

--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -229,7 +229,7 @@ func (r *ReverseProxy) AddSubdomain(subdomain string, ipaddress string, targetPo
 		handler.Transport = &Transport{
 			Transport: http.DefaultTransport,
 			Counter:   counter,
-			Timeout:   r.cfg.ProxyTimeout,
+			Timeout:   r.cfg.Network.ProxyTimeout,
 			Subdomain: subdomain,
 		}
 		ph.add(v.ListenPort, addr, handler)

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,74 @@
+package mirageecs_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	mirageecs "github.com/acidlemon/mirage-ecs"
+)
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		serverDelay time.Duration
+		timeout     time.Duration
+		wantStatus  int
+		wantBody    string
+	}{
+		{
+			name:        "Success pattern",
+			serverDelay: 50 * time.Millisecond,
+			timeout:     100 * time.Millisecond,
+			wantStatus:  http.StatusOK,
+			wantBody:    "OK",
+		},
+		{
+			name:        "Timeout failure pattern",
+			serverDelay: 150 * time.Millisecond,
+			timeout:     100 * time.Millisecond,
+			wantStatus:  http.StatusGatewayTimeout,
+			wantBody:    "test-subdomain upstream timeout: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(tt.serverDelay)
+				w.Write([]byte("OK"))
+			}))
+			defer server.Close()
+
+			// Setup transport
+			tr := &mirageecs.Transport{
+				Counter:   mirageecs.NewAccessCounter(time.Second),
+				Transport: http.DefaultTransport,
+				Timeout:   tt.timeout,
+				Subdomain: "test-subdomain",
+			}
+
+			req, _ := http.NewRequest("GET", server.URL, nil)
+
+			resp, err := tr.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("wanted status %v, got %v", tt.wantStatus, resp.StatusCode)
+			}
+
+			if !strings.Contains(string(body), tt.wantBody) {
+				t.Errorf("wanted body to contain %v, got %v", tt.wantBody, string(body))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enables to set timeout to http.Transport for reverse proxy.

```yaml
network:
  proxy_timeout: 30s
```

When a proxy request is timed out, returns HTTP 504 (Bad Gateway).