### PR TITLE
Set SubdomainRaw tag and environment variable.

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -68,11 +68,17 @@ func (info Information) ShouldBePurged(duration time.Duration, excludesMap map[s
 type TaskParameter map[string]string
 
 func (p TaskParameter) ToECSKeyValuePairs(subdomain string, configParams Parameters) []types.KeyValuePair {
-	kvp := make([]types.KeyValuePair, 0, len(p)+1)
-	kvp = append(kvp, types.KeyValuePair{
-		Name:  aws.String(strings.ToUpper(TagSubdomain)),
-		Value: aws.String(encodeTagValue(subdomain)),
-	})
+	kvp := make([]types.KeyValuePair, 0, len(p)+2)
+	kvp = append(kvp,
+		types.KeyValuePair{
+			Name:  aws.String(strings.ToUpper(TagSubdomain)),
+			Value: aws.String(encodeTagValue(subdomain)),
+		},
+		types.KeyValuePair{
+			Name:  aws.String(TagSubdomainRaw),
+			Value: aws.String(subdomain),
+		},
+	)
 	for _, v := range configParams {
 		v := v
 		if p[v.Name] == "" {
@@ -87,11 +93,15 @@ func (p TaskParameter) ToECSKeyValuePairs(subdomain string, configParams Paramet
 }
 
 func (p TaskParameter) ToECSTags(subdomain string, configParams Parameters) []types.Tag {
-	tags := make([]types.Tag, 0, len(p)+2)
+	tags := make([]types.Tag, 0, len(p)+3)
 	tags = append(tags,
 		types.Tag{
 			Key:   aws.String(TagSubdomain),
 			Value: aws.String(encodeTagValue(subdomain)),
+		},
+		types.Tag{
+			Key:   aws.String(TagSubdomainRaw),
+			Value: aws.String(subdomain),
 		},
 		types.Tag{
 			Key:   aws.String(TagManagedBy),
@@ -125,9 +135,10 @@ func (p TaskParameter) ToEnv(subdomain string, configParams Parameters) map[stri
 }
 
 const (
-	TagManagedBy   = "ManagedBy"
-	TagSubdomain   = "Subdomain"
-	TagValueMirage = "Mirage"
+	TagManagedBy    = "ManagedBy"
+	TagSubdomain    = "Subdomain"
+	TagSubdomainRaw = "SubdomainRaw"
+	TagValueMirage  = "Mirage"
 
 	statusRunning = string(types.DesiredStatusRunning)
 	statusStopped = string(types.DesiredStatusStopped)

--- a/ecs.go
+++ b/ecs.go
@@ -124,6 +124,7 @@ func (p TaskParameter) ToECSTags(subdomain string, configParams Parameters) []ty
 func (p TaskParameter) ToEnv(subdomain string, configParams Parameters) map[string]string {
 	env := make(map[string]string, len(p)+1)
 	env[strings.ToUpper(TagSubdomain)] = encodeTagValue(subdomain)
+	env[strings.ToUpper(TagSubdomainRaw)] = subdomain
 	for _, v := range configParams {
 		v := v
 		if p[v.Name] == "" {

--- a/ecs.go
+++ b/ecs.go
@@ -75,7 +75,7 @@ func (p TaskParameter) ToECSKeyValuePairs(subdomain string, configParams Paramet
 			Value: aws.String(encodeTagValue(subdomain)),
 		},
 		types.KeyValuePair{
-			Name:  aws.String(TagSubdomainRaw),
+			Name:  aws.String(strings.ToUpper(TagSubdomainRaw)),
 			Value: aws.String(subdomain),
 		},
 	)

--- a/ecs_test.go
+++ b/ecs_test.go
@@ -36,19 +36,22 @@ func TestToECSKeyValuePairsAndTags(t *testing.T) {
 			subdomain: "testsubdomain",
 			expectedKVP: []types.KeyValuePair{
 				{Name: aws.String("SUBDOMAIN"), Value: aws.String("dGVzdHN1YmRvbWFpbg==")},
+				{Name: aws.String("SUBDOMAINRAW"), Value: aws.String("testsubdomain")},
 				{Name: aws.String("ENV1"), Value: aws.String("Value1")},
 				{Name: aws.String("ENV2"), Value: aws.String("Value2")},
 			},
 			expectedTags: []types.Tag{
 				{Key: aws.String("Subdomain"), Value: aws.String("dGVzdHN1YmRvbWFpbg==")},
+				{Key: aws.String("SubdomainRaw"), Value: aws.String("testsubdomain")},
 				{Key: aws.String("ManagedBy"), Value: aws.String(mirageecs.TagValueMirage)},
 				{Key: aws.String("Param1"), Value: aws.String("Value1")},
 				{Key: aws.String("Param2"), Value: aws.String("Value2")},
 			},
 			expectedEnv: map[string]string{
-				"SUBDOMAIN": "dGVzdHN1YmRvbWFpbg==",
-				"ENV1":      "Value1",
-				"ENV2":      "Value2",
+				"SUBDOMAIN":    "dGVzdHN1YmRvbWFpbg==",
+				"SUBDOMAINRAW": "testsubdomain",
+				"ENV1":         "Value1",
+				"ENV2":         "Value2",
 			},
 		},
 	}


### PR DESCRIPTION
Currently, mirage-ecs sets tag named `Subdomain` and environment variable `SUBDOMAIN`. These values are encoded as base64 for historical reasons.

But, base64 encoded values make it difficult to handle.

This PR adds a tag named `SubdomainRaw` and environment variable `SUBDOMAINRAW` having raw values.