### PR TITLE
add requre_auth_cookie feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ auth:
 
 `cookie_secret` section configures secret key for cookie authentication.
 
-When you configure `cookie_secret`, mirage-ecs sets a cookie to the browser after authorized by other authentication methods. The cookie is used to authenticate the request to reverse proxies for the target ECS tasks.
+When you configure `cookie_secret`, mirage-ecs sets a cookie to the browser after being authorized by other authentication methods. The cookie is used to authenticate the next request for webapi and reverse proxy to the target ECS tasks.
 
 ##### `token` section
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ listen:
   http:
     - listen: 80 # port number of mirage-ecs webapi
       target: 80 # port number of target ECS task
+      require_auth_cookie: true # require auth cookie to access to target ECS task
+```
+
+When `require_auth_cookie` is true, mirage-ecs requires a cookie to access to target ECS task. mirage-ecs sets a cookie to the browser if authorized by other authentication methods. The cookie is used to authenticate the request to target ECS task. See also `cookie_secret` section in `auth` configuration.
+
+When `require_auth_cookie` is false (default), mirage-ecs does not restrict access to target ECS task.
+
+This configuration allows to specify multiple ports. mirage-ecs listens to all ports and proxies to the target ECS task.
+
+```yaml
+listen:
+  http:
+    - listen: 3000
+      target: 3000
+      require_auth_cookie: true
+    - listen: 5000
+      target: 5000
+      require_auth_cookie: false
 ```
 
 #### `network` section
@@ -334,6 +352,7 @@ If you configure multiple authentication methods, mirage-ecs checks the methods 
 
 ```yaml
 auth:
+  cookie_secret: "{{ env `MIRAGE_COOKIE_SECRET` }}"
   token:
     header: x-mirage-token
     token: "{{ env `MIRAGE_TOKEN` }}"
@@ -346,6 +365,12 @@ auth:
     username: mirage
     password: "{{ env `MIRAGE_PASSWORD` }}"
 ```
+
+#### `cookie_secret` section
+
+`cookie_secret` section configures secret key for cookie authentication.
+
+When you configure `cookie_secret`, mirage-ecs sets a cookie to the browser after authorized by other authentication methods. The cookie is used to authenticate the request to reverse proxies for the target ECS tasks.
 
 ##### `token` section
 

--- a/auth.go
+++ b/auth.go
@@ -29,6 +29,17 @@ func (a *Auth) Do(req *http.Request, res http.ResponseWriter) (bool, error) {
 		// no auth
 		return true, nil
 	}
+
+	if cookie, err := req.Cookie(AuthCookieName); err == nil {
+		if err := a.ValidateAuthCookie(cookie); err != nil {
+			log.Printf("[warn] auth cookie failed: %s", err)
+			// fallthrough
+		} else {
+			log.Println("[debug] auth cookie succeeded")
+			return true, nil
+		}
+	}
+
 	if ok := a.Token.Match(req.Header); ok {
 		return ok, nil
 	}

--- a/auth.go
+++ b/auth.go
@@ -12,9 +12,10 @@ import (
 )
 
 type Auth struct {
-	Basic    *AuthMethodBasic    `yaml:"basic"`
-	Token    *AuthMethodToken    `yaml:"token"`
-	AmznOIDC *AuthMethodAmznOIDC `yaml:"amzn_oidc"`
+	Basic        *AuthMethodBasic    `yaml:"basic"`
+	Token        *AuthMethodToken    `yaml:"token"`
+	AmznOIDC     *AuthMethodAmznOIDC `yaml:"amzn_oidc"`
+	CookieSecret string              `yaml:"cookie_secret"`
 }
 
 func (a *Auth) Do(req *http.Request, res http.ResponseWriter) (bool, error) {

--- a/auth.go
+++ b/auth.go
@@ -51,13 +51,7 @@ func (a *Auth) NewAuthCookie(expire time.Duration, domain string) (*http.Cookie,
 	expireAt := time.Now().Add(expire)
 
 	if a == nil || a.CookieSecret == "" {
-		return &http.Cookie{
-			Name:     AuthCookieName,
-			Value:    "nil",
-			Expires:  expireAt,
-			Domain:   domain,
-			HttpOnly: true,
-		}, nil
+		return &http.Cookie{}, nil
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,8 +1,10 @@
-package mirageecs
+package mirageecs_test
 
 import (
 	"net/http"
 	"testing"
+
+	mirageecs "github.com/acidlemon/mirage-ecs"
 )
 
 func TestAuthMethodToken_Match(t *testing.T) {
@@ -96,12 +98,12 @@ func TestAuthMethodToken_Match(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &AuthMethodToken{
+			b := &mirageecs.AuthMethodToken{
 				Token:  tt.fields.Token,
 				Header: tt.fields.Header,
 			}
 			if got := b.Match(tt.args.h); got != tt.want {
-				t.Errorf("AuthMethodToken.Match() = %v, want %v", got, tt.want)
+				t.Errorf("mirageecs.mirageecs.AuthMethodToken.Match() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -110,7 +112,7 @@ func TestAuthMethodToken_Match(t *testing.T) {
 func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 	type fields struct {
 		Claim    string
-		Matchers []*ClaimMatcher
+		Matchers []*mirageecs.ClaimMatcher
 	}
 	type args struct {
 		Claims map[string]any
@@ -125,7 +127,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim matches",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Exact: "user@example.com",
 					},
@@ -142,7 +144,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim does not match",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Exact: "user@example.com",
 					},
@@ -159,7 +161,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim is empty",
 			fields: fields{
 				Claim: "",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Exact: "user@example.com",
 					},
@@ -176,7 +178,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim matches suffix",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Suffix: "@example.com",
 					},
@@ -193,7 +195,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim does not match suffix",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Suffix: "@example.com",
 					},
@@ -210,7 +212,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim matches any suffix",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Suffix: "@example.com",
 					},
@@ -230,7 +232,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim matches any exact",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Exact: "foo@example.com",
 					},
@@ -250,7 +252,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim match both",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Suffix: "@example.com",
 					},
@@ -270,7 +272,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 			name: "Claim does not match both",
 			fields: fields{
 				Claim: "email",
-				Matchers: []*ClaimMatcher{
+				Matchers: []*mirageecs.ClaimMatcher{
 					{
 						Suffix: "@example.net",
 					},
@@ -289,7 +291,7 @@ func TestAuthMethodAmznOIDC_Match(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := &AuthMethodAmznOIDC{
+			a := &mirageecs.AuthMethodAmznOIDC{
 				Claim:    tt.fields.Claim,
 				Matchers: tt.fields.Matchers,
 			}
@@ -392,7 +394,7 @@ func TestAuthMethodBasic_Match(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &AuthMethodBasic{
+			b := &mirageecs.AuthMethodBasic{
 				Username: tt.fields.Username,
 				Password: tt.fields.Password,
 			}

--- a/config.go
+++ b/config.go
@@ -404,7 +404,9 @@ func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			log.Println("[error] failed to create auth cookie:", err)
 			return echo.ErrInternalServerError
 		}
-		c.SetCookie(cookie)
+		if cookie.Value != "" {
+			c.SetCookie(cookie)
+		}
 
 		if !ok {
 			log.Println("[warn] auth failed")

--- a/config.go
+++ b/config.go
@@ -399,7 +399,7 @@ func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return echo.ErrInternalServerError
 		}
 		// set cookie if auth succeeded
-		cookie, err := cfg.Auth.newAuthCookie(AuthCookieExpire, cfg.Host.ReverseProxySuffix)
+		cookie, err := cfg.Auth.NewAuthCookie(AuthCookieExpire, cfg.Host.ReverseProxySuffix)
 		if err != nil {
 			log.Println("[error] failed to create auth cookie:", err)
 			return echo.ErrInternalServerError

--- a/config.go
+++ b/config.go
@@ -399,16 +399,16 @@ func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return echo.ErrInternalServerError
 		}
 		// set cookie if auth succeeded
-		cookie, err := cfg.Auth.NewAuthCookie(AuthCookieExpire, cfg.Host.ReverseProxySuffix)
-		if err != nil {
-			log.Println("[error] failed to create auth cookie:", err)
-			return echo.ErrInternalServerError
-		}
-		if cookie.Value != "" {
-			c.SetCookie(cookie)
-		}
-
-		if !ok {
+		if ok {
+			cookie, err := cfg.Auth.NewAuthCookie(AuthCookieExpire, cfg.Host.ReverseProxySuffix)
+			if err != nil {
+				log.Println("[error] failed to create auth cookie:", err)
+				return echo.ErrInternalServerError
+			}
+			if cookie.Value != "" {
+				c.SetCookie(cookie)
+			}
+		} else {
 			log.Println("[warn] auth failed")
 			return echo.ErrUnauthorized
 		}

--- a/config.go
+++ b/config.go
@@ -162,8 +162,9 @@ type Listen struct {
 }
 
 type PortMap struct {
-	ListenPort int `yaml:"listen"`
-	TargetPort int `yaml:"target"`
+	ListenPort        int  `yaml:"listen"`
+	TargetPort        int  `yaml:"target"`
+	RequireAuthCookie bool `yaml:"require_auth_cookie"`
 }
 
 type Parameter struct {
@@ -197,6 +198,7 @@ type Network struct {
 
 const DefaultPort = 80
 const DefaultProxyTimeout = 0
+const AuthCookieName = "mirage-ecs-auth"
 
 func NewConfig(ctx context.Context, p *ConfigParams) (*Config, error) {
 	domain := p.Domain
@@ -387,12 +389,26 @@ func (c *Config) fillECSDefaults(ctx context.Context) error {
 	return nil
 }
 
+func (cfg *Config) newCookie() (*http.Cookie, error) {
+	return &http.Cookie{
+		Name:    AuthCookieName,
+		Value:   "ok", // TODO jwt
+		Expires: time.Now().Add(24 * time.Hour),
+		Domain:  cfg.Host.ReverseProxySuffix,
+		// Secure:  true,
+	}, nil
+}
+
 func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		ok, err := cfg.Auth.Do(c.Request(), c.Response())
 		if err != nil {
 			log.Println("[error] auth error:", err)
 			return echo.ErrInternalServerError
+		}
+		if cfg.Auth == nil || ok {
+			cookie, _ := cfg.newCookie()
+			c.SetCookie(cookie)
 		}
 		if !ok {
 			log.Println("[warn] auth failed")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.37.0
 	github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd
 	github.com/fujiwara/go-amzn-oidc v0.0.7
+	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kayac/go-config v0.7.0
@@ -40,7 +41,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.3 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,6 +1,7 @@
 package mirageecs_test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -64,11 +65,18 @@ func TestRoundTrip(t *testing.T) {
 
 			// Setup transport
 			tr := &mirageecs.Transport{
-				Counter:           mirageecs.NewAccessCounter(time.Second),
-				Transport:         http.DefaultTransport,
-				Timeout:           tt.timeout,
-				Subdomain:         "test-subdomain",
-				RequireAuthCookie: tt.requireAuthCookie,
+				Counter:   mirageecs.NewAccessCounter(time.Second),
+				Transport: http.DefaultTransport,
+				Timeout:   tt.timeout,
+				Subdomain: "test-subdomain",
+			}
+			if tt.requireAuthCookie {
+				tr.AuthCookieValueValidateFunc = func(v string) error {
+					if v == "ok" {
+						return nil
+					}
+					return fmt.Errorf("invalid cookie value: %s", v)
+				}
 			}
 
 			req, _ := http.NewRequest("GET", server.URL, nil)

--- a/transport_test.go
+++ b/transport_test.go
@@ -71,11 +71,11 @@ func TestRoundTrip(t *testing.T) {
 				Subdomain: "test-subdomain",
 			}
 			if tt.requireAuthCookie {
-				tr.AuthCookieValueValidateFunc = func(v string) error {
-					if v == "ok" {
+				tr.AuthCookieValidateFunc = func(c *http.Cookie) error {
+					if c.Value == "ok" {
 						return nil
 					}
-					return fmt.Errorf("invalid cookie value: %s", v)
+					return fmt.Errorf("invalid cookie value: %s", c.Value)
 				}
 			}
 


### PR DESCRIPTION
This PR adds `cookie_secret` and `require_auth_cookie` configurations.

```yaml
listen:
  http:
    - listen: 80
      target: 80
      require_auth_cookie: true

auth:
  cookie_secret: "secretsecretsecret"
  amzn_oidc:
    claim: email
    matcher:
      - suffix: "@example.com"
      - exact: "foo@example.net"
```

When you configure `cookie_secret`, mirage-ecs sets a cookie to the browser after authorized by other authentication methods via access to webapi. The cookie is used to authenticate the request to reverse proxies for the target ECS tasks.

When `require_auth_cookie` is true, mirage-ecs requires a cookie to access to target ECS task.
