### PR TITLE
Fix/csrf more

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ See "mirage link" section for details.
 
 This section is optional.
 
-mirage-ecs supports token authentication, basic authentication and Amazon OIDC authentication by Application Load Balancer. You can use multiple authentication methods at the same time.
+mirage-ecs supports token authentication, basic authentication and Amazon OIDC authentication by Application Load Balancer for web browser access (excludes requests for `/api/*`). You can use multiple authentication methods at the same time.
 
 If you configure multiple authentication methods, mirage-ecs checks the methods in order token, Amazon OIDC, and basic.  When some method succeeds, mirage-ecs allows access.
 
@@ -370,7 +370,10 @@ auth:
 
 `cookie_secret` section configures secret key for cookie authentication.
 
-When you configure `cookie_secret`, mirage-ecs sets a cookie to the browser after being authorized by other authentication methods. The cookie is used to authenticate the next request for webapi and reverse proxy to the target ECS tasks.
+When you configure `cookie_secret`, mirage-ecs sets a cookie to the browser after being authorized by other authentication methods. The cookie is used to authenticate the next request for web browser access and reverse proxy to the target ECS tasks.
+
+When `/api/*` is accessed, mirage-ecs does not set a cookie to the clients. The `/api/*`
+paths allow authentication by token only.
 
 ##### `token` section
 

--- a/auth.go
+++ b/auth.go
@@ -78,6 +78,8 @@ func (a *Auth) NewAuthCookie(expire time.Duration, domain string) (*http.Cookie,
 		Expires:  expireAt,
 		Domain:   domain,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   true,
 	}, nil
 }
 

--- a/auth.go
+++ b/auth.go
@@ -26,22 +26,6 @@ type Auth struct {
 
 type Authorizer func(req *http.Request, res http.ResponseWriter) (bool, error)
 
-func (a *Auth) ByCookie(req *http.Request, res http.ResponseWriter) (bool, error) {
-	if cookie, err := req.Cookie(AuthCookieName); err == nil {
-		if err := a.ValidateAuthCookie(cookie); err != nil {
-			log.Printf("[warn] auth cookie failed: %s", err)
-			return false, nil
-		} else {
-			log.Println("[debug] auth cookie succeeded")
-			return true, nil
-		}
-	} else {
-		log.Println("[debug] auth cookie not found")
-		// no cookie
-		return false, nil
-	}
-}
-
 func (a *Auth) ByBasic(req *http.Request, res http.ResponseWriter) (bool, error) {
 	if a == nil || a.Basic == nil {
 		return false, nil

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -394,22 +395,22 @@ func (c *Config) fillECSDefaults(ctx context.Context) error {
 func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		isAPIRequest := strings.HasPrefix(c.Request().URL.Path, "/api/")
-		methods := []AuthMethod{cfg.Auth.ByToken}
+		runs := []Authorizer{cfg.Auth.ByToken}
 		if !isAPIRequest {
 			// web access allows other auth methods
-			methods = append(methods,
+			runs = append(runs,
 				cfg.Auth.ByCookie,
 				cfg.Auth.ByAmznOIDC,
 				cfg.Auth.ByBasic, // basic auth must be evaluated at last
 			)
 		}
-		ok, err := cfg.Auth.Do(c.Request(), c.Response(), methods...)
+		ok, err := cfg.Auth.Do(c.Request(), c.Response(), runs...)
 		if err != nil {
 			log.Println("[error] auth error:", err)
 			return echo.ErrInternalServerError
 		}
 		if !ok {
-			log.Println("[warn] auth failed")
+			log.Println("[warn] all auth methods failed")
 			return echo.ErrUnauthorized
 		}
 
@@ -528,4 +529,19 @@ func copyToFile(src io.Reader, dst string) (int64, error) {
 	}
 	defer f.Close()
 	return io.Copy(f, src)
+}
+
+func (cfg *Config) ValidateOrigin(origin string) error {
+	if origin == "" {
+		return fmt.Errorf("origin required")
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("invalid origin: %s", origin)
+	}
+	host, _, _ := net.SplitHostPort(u.Host)
+	if host != cfg.Host.WebApi {
+		return fmt.Errorf("invalid origin host: %s", u.Host)
+	}
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -399,7 +399,6 @@ func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		if !isAPIRequest {
 			// web access allows other auth methods
 			runs = append(runs,
-				cfg.Auth.ByCookie,
 				cfg.Auth.ByAmznOIDC,
 				cfg.Auth.ByBasic, // basic auth must be evaluated at last
 			)

--- a/config_auth_test.go
+++ b/config_auth_test.go
@@ -1,0 +1,258 @@
+package mirageecs_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mirageecs "github.com/acidlemon/mirage-ecs"
+	"github.com/labstack/echo/v4"
+)
+
+func TestAuthMiddleware(t *testing.T) {
+	config := &mirageecs.Config{
+		Host: mirageecs.Host{
+			WebApi:             "mirage.localtest.me",
+			ReverseProxySuffix: ".localtest.me",
+		},
+		Auth: &mirageecs.Auth{
+			CookieSecret: "cookie-secret",
+			Token: &mirageecs.AuthMethodToken{
+				Header: "x-mirage-token",
+				Token:  "mytoken",
+			},
+			Basic: &mirageecs.AuthMethodBasic{
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}
+
+	var validCookie *http.Cookie
+	validateCookie := func(cookies []*http.Cookie) error {
+		for _, c := range cookies {
+			if c.Name == mirageecs.AuthCookieName && c.HttpOnly && c.Secure && c.Domain == "localtest.me" {
+				validCookie = c
+				return nil
+			}
+		}
+		return fmt.Errorf("cookie is not set correctly %v", cookies)
+	}
+
+	cases := []struct {
+		Name         string
+		Request      func() *http.Request
+		ExpectStatus int
+		Expect       func(*http.Response) error
+		BodyContains string
+	}{
+		{
+			Name: "Token matches",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("x-mirage-token", "mytoken")
+				return req
+			},
+			ExpectStatus: 200,
+			Expect: func(res *http.Response) error {
+				if err := validateCookie(res.Cookies()); err != nil {
+					return err
+				}
+				return nil
+			},
+			BodyContains: "ok",
+		},
+		{
+			Name: "Token does not match",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("x-mirage-token", "othertoken")
+				return req
+			},
+			ExpectStatus: 401,
+			Expect: func(res *http.Response) error {
+				if res.Header.Get("WWW-Authenticate") != `Basic realm="Restricted"` {
+					return fmt.Errorf("WWW-Authenticate header is not set")
+				}
+				if len(res.Cookies()) != 0 {
+					return fmt.Errorf("cookie should not be set %v", res.Cookies())
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Basic matches",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.SetBasicAuth("user", "pass")
+				return req
+			},
+			ExpectStatus: 200,
+			Expect: func(res *http.Response) error {
+				if err := validateCookie(res.Cookies()); err != nil {
+					return err
+				}
+				return nil
+			},
+			BodyContains: "ok",
+		},
+		{
+			Name: "Basic does not match",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.SetBasicAuth("userx", "pass")
+				return req
+			},
+			ExpectStatus: 401,
+			Expect: func(res *http.Response) error {
+				if len(res.Cookies()) != 0 {
+					return fmt.Errorf("cookie should not be set %v", res.Cookies())
+				}
+				return nil
+			},
+		},
+		{
+			Name: "token matches, basic does not match",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("x-mirage-token", "mytoken")
+				req.SetBasicAuth("userx", "pass")
+				return req
+			},
+			ExpectStatus: 200,
+			Expect: func(res *http.Response) error {
+				if err := validateCookie(res.Cookies()); err != nil {
+					return err
+				}
+				return nil
+			},
+			BodyContains: "ok",
+		},
+		{
+			Name: "/api/* don't allow basic auth",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/api/list", nil)
+				req.SetBasicAuth("user", "pass")
+				return req
+			},
+			ExpectStatus: 401,
+			Expect: func(res *http.Response) error {
+				if len(res.Cookies()) != 0 {
+					return fmt.Errorf("cookie should not be set %v", res.Cookies())
+				}
+				return nil
+			},
+		},
+		{
+			Name: "POST /launch requries origin header",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/launch", nil)
+				req.SetBasicAuth("user", "pass")
+				return req
+			},
+			ExpectStatus: 400,
+		},
+		{
+			Name: "POST /launch succeeds with valid origin header with basic auth",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/launch", nil)
+				req.SetBasicAuth("user", "pass")
+				req.Header.Set("Origin", "https://mirage.localtest.me:8000")
+				return req
+			},
+			ExpectStatus: 200,
+			BodyContains: "launched",
+		},
+		{
+			Name: "POST /launch succeeds with valid origin header with valid cookie",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/launch", nil)
+				req.AddCookie(validCookie)
+				req.Header.Set("Origin", "https://mirage.localtest.me:8000")
+				return req
+			},
+			ExpectStatus: 200,
+			BodyContains: "launched",
+		},
+		{
+			Name: "POST /launch invalid host origin header",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/launch", nil)
+				req.Header.Add("origin", "https://xxx.localtest.me:8000")
+				req.AddCookie(validCookie)
+				return req
+			},
+			ExpectStatus: 400,
+		},
+		{
+			Name: "Authorized by valid cookie",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.AddCookie(validCookie)
+				return req
+			},
+			ExpectStatus: 200,
+			BodyContains: "ok",
+		},
+		{
+			Name: "/api/* don't allow cookie auth",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/api/list", nil)
+				req.AddCookie(validCookie)
+				return req
+			},
+			ExpectStatus: 401,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			e := echo.New()
+			handler := func(c echo.Context) error {
+				p := c.Request().URL.Path
+				log.Printf("[debug] handler called %s", p)
+				switch p {
+				case "/":
+					return c.String(http.StatusOK, "ok")
+				case "/api/list":
+					return c.JSON(http.StatusOK, []int{})
+				case "/launch":
+					log.Printf("[debug] origin: %s", c.Request().Header.Get("Origin"))
+					if err := config.ValidateOrigin(c.Request().Header.Get("Origin")); err != nil {
+						log.Printf("[debug] origin validation failed: %s", err)
+						return c.String(http.StatusBadRequest, err.Error())
+					}
+					return c.String(http.StatusOK, "launched")
+				default:
+					return c.String(http.StatusNotFound, "not found")
+				}
+			}
+			middleware := config.AuthMiddleware(handler)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(tc.Request(), rec)
+			err := middleware(c)
+			if err == nil {
+				if rec.Code != tc.ExpectStatus {
+					t.Errorf("unexpected status code: %d", rec.Code)
+				}
+			} else {
+				if code := err.(*echo.HTTPError).Code; code != tc.ExpectStatus {
+					t.Errorf("unexpected status code: %d", code)
+				}
+			}
+			if tc.Expect != nil {
+				if err := tc.Expect(rec.Result()); err != nil {
+					t.Error(err)
+				}
+			}
+			if tc.BodyContains != "" {
+				if !strings.Contains(rec.Body.String(), tc.BodyContains) {
+					t.Errorf("body does not contain %s got: %s", tc.BodyContains, rec.Body.String())
+				}
+			}
+		})
+	}
+}

--- a/config_auth_test.go
+++ b/config_auth_test.go
@@ -167,38 +167,17 @@ func TestAuthMiddleware(t *testing.T) {
 			BodyContains: "launched",
 		},
 		{
-			Name: "POST /launch succeeds with valid origin header with valid cookie",
+			Name: "POST /launch fails with valid origin header with valid cookie only",
 			Request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodPost, "/launch", nil)
 				req.AddCookie(validCookie)
 				req.Header.Set("Origin", "https://mirage.localtest.me:8000")
 				return req
 			},
-			ExpectStatus: 200,
-			BodyContains: "launched",
+			ExpectStatus: 401,
 		},
 		{
-			Name: "POST /launch invalid host origin header",
-			Request: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "/launch", nil)
-				req.Header.Add("origin", "https://xxx.localtest.me:8000")
-				req.AddCookie(validCookie)
-				return req
-			},
-			ExpectStatus: 400,
-		},
-		{
-			Name: "Authorized by valid cookie",
-			Request: func() *http.Request {
-				req := httptest.NewRequest(http.MethodGet, "/", nil)
-				req.AddCookie(validCookie)
-				return req
-			},
-			ExpectStatus: 200,
-			BodyContains: "ok",
-		},
-		{
-			Name: "/api/* don't allow cookie auth",
+			Name: "webapi dosen't allow cookie auth",
 			Request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, "/api/list", nil)
 				req.AddCookie(validCookie)

--- a/webapi.go
+++ b/webapi.go
@@ -7,7 +7,9 @@ import (
 	"html/template"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"regexp"
 	"sort"
@@ -80,6 +82,22 @@ func NewWebApi(cfg *Config, runner TaskRunner) *WebApi {
 	return app
 }
 
+func (api *WebApi) ValidateOrigin(c echo.Context) error {
+	origin := c.Request().Header.Get("Origin")
+	if origin == "" {
+		return fmt.Errorf("origin required")
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("invalid origin: %s", origin)
+	}
+	host, _, _ := net.SplitHostPort(u.Host)
+	if host != api.cfg.Host.WebApi {
+		return fmt.Errorf("invalid origin host: %s", u.Host)
+	}
+	return nil
+}
+
 func (api *WebApi) Top(c echo.Context) error {
 	return c.Render(http.StatusOK, "layout.html", map[string]interface{}{})
 }
@@ -129,6 +147,9 @@ func (api *WebApi) Launcher(c echo.Context) error {
 }
 
 func (api *WebApi) Launch(c echo.Context) error {
+	if err := api.ValidateOrigin(c); err != nil {
+		return c.String(http.StatusBadRequest, err.Error())
+	}
 	code, err := api.launch(c)
 	if err != nil {
 		return c.String(code, err.Error())
@@ -140,6 +161,9 @@ func (api *WebApi) Launch(c echo.Context) error {
 }
 
 func (api *WebApi) Terminate(c echo.Context) error {
+	if err := api.ValidateOrigin(c); err != nil {
+		return c.String(http.StatusBadRequest, err.Error())
+	}
 	code, err := api.terminate(c)
 	if err != nil {
 		c.String(code, err.Error())


### PR DESCRIPTION
- `POST /(launch|terminate)` requires a valid origin header.
  - Modern web browsers send an origin header.
- `/api/*` allows token authentication only.
  - Web browsers should not call `/api/*`.
  - CLIs or API clients should not use cookies or basic auth headers.
- mirage web access blocks cookie auth.
  - Cookie authentication is for reverse proxy access only.

This PR contains breaks backward compatibility about API authentications.