### PR TITLE
API accespts application/json only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ This section is optional.
 
 mirage-ecs supports token authentication, basic authentication and Amazon OIDC authentication by Application Load Balancer for web browser access (excludes requests for `/api/*`). You can use multiple authentication methods at the same time.
 
+For `/api/*` requests, mirage-ecs allows access by token authentication only.
+
 If you configure multiple authentication methods, mirage-ecs checks the methods in order token, Amazon OIDC, and basic.  When some method succeeds, mirage-ecs allows access.
 
 ```yaml
@@ -452,8 +454,11 @@ link:
 
 mirage-ecs provides the following APIs.
 
-POST APIs are accepts parameters from a request body as `application/x-www-form-urlencoded` or `application/json`.
-GET APIs are only accepts URL query parameters.
+POST APIs are accepts parameters from a request body as `content-type: application/json`.
+
+For v1 backward compatibility, `-compat-v1` cli flag enables accepting `application/x-www-form-urlencoded`. But this feature may cause CSRF vulnerability. We recommend to use `application/json` only (v2 defaults).
+
+GET APIs only accept URL query parameters.
 
 ### `GET /api/list`
 

--- a/cmd/mirage-ecs/main.go
+++ b/cmd/mirage-ecs/main.go
@@ -23,12 +23,13 @@ var (
 func main() {
 	confFile := flag.String("conf", "", "specify config file or S3 URL")
 	domain := flag.String("domain", ".local", "reverse proxy suffix")
-	var showVersion, showConfig, localMode bool
+	var showVersion, showConfig, localMode, compatV1 bool
 	var defaultPort int
 	flag.BoolVar(&showVersion, "version", false, "show version")
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	flag.BoolVar(&showConfig, "x", false, "show config")
 	flag.BoolVar(&localMode, "local", false, "local mode (for development)")
+	flag.BoolVar(&compatV1, "compat-v1", false, "compatibility mode for v1")
 	flag.IntVar(&defaultPort, "default-port", 80, "default port number")
 	logLevel := flag.String("log-level", "info", "log level (trace, debug, info, warn, error)")
 	flag.VisitAll(overrideWithEnv)
@@ -56,6 +57,7 @@ func main() {
 		LocalMode:   localMode,
 		Domain:      *domain,
 		DefaultPort: defaultPort,
+		CompatV1:    compatV1,
 	})
 	if err != nil {
 		log.Fatalf("[error] %s", err)

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Link      Link       `yaml:"link"`
 	Auth      *Auth      `yaml:"auth"`
 
+	compatV1  bool
 	localMode bool
 	awscfg    *aws.Config
 	cleanups  []func() error
@@ -191,6 +192,7 @@ type ConfigParams struct {
 	Domain      string
 	LocalMode   bool
 	DefaultPort int
+	CompatV1    bool
 }
 
 type Network struct {
@@ -230,8 +232,10 @@ func NewConfig(ctx context.Context, p *ConfigParams) (*Config, error) {
 		ECS: ECSCfg{
 			Region: os.Getenv("AWS_REGION"),
 		},
+		Auth: nil,
+
 		localMode: p.LocalMode,
-		Auth:      nil,
+		compatV1:  p.CompatV1,
 	}
 
 	if awscfg, err := awsv2Config.LoadDefaultConfig(ctx, awsv2Config.WithRegion(cfg.ECS.Region)); err != nil {
@@ -403,18 +407,11 @@ func (c *Config) fillECSDefaults(ctx context.Context) error {
 	return nil
 }
 
-func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+func (cfg *Config) AuthMiddlewareForWeb(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		isAPIRequest := strings.HasPrefix(c.Request().URL.Path, "/api/")
-		runs := []Authorizer{cfg.Auth.ByToken}
-		if !isAPIRequest {
-			// web access allows other auth methods
-			runs = append(runs,
-				cfg.Auth.ByAmznOIDC,
-				cfg.Auth.ByBasic, // basic auth must be evaluated at last
-			)
-		}
-		ok, err := cfg.Auth.Do(c.Request(), c.Response(), runs...)
+		ok, err := cfg.Auth.Do(c.Request(), c.Response(),
+			cfg.Auth.ByToken, cfg.Auth.ByAmznOIDC, cfg.Auth.ByBasic,
+		)
 		if err != nil {
 			log.Println("[error] auth error:", err)
 			return echo.ErrInternalServerError
@@ -424,15 +421,45 @@ func (cfg *Config) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return echo.ErrUnauthorized
 		}
 
-		// set auth cookie for web access
-		if !isAPIRequest {
-			cookie, err := cfg.Auth.NewAuthCookie(AuthCookieExpire, cfg.Host.ReverseProxySuffix)
-			if err != nil {
-				log.Println("[error] failed to create auth cookie:", err)
-				return echo.ErrInternalServerError
-			}
-			if cookie.Value != "" {
-				c.SetCookie(cookie)
+		cookie, err := cfg.Auth.NewAuthCookie(AuthCookieExpire, cfg.Host.ReverseProxySuffix)
+		if err != nil {
+			log.Println("[error] failed to create auth cookie:", err)
+			return echo.ErrInternalServerError
+		}
+		if cookie.Value != "" {
+			c.SetCookie(cookie)
+		}
+		return next(c)
+	}
+}
+
+func (cfg *Config) AuthMiddlewareForAPI(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		// API allows only token auth
+		ok, err := cfg.Auth.Do(c.Request(), c.Response(), cfg.Auth.ByToken)
+		if err != nil {
+			log.Println("[error] auth error:", err)
+			return echo.ErrInternalServerError
+		}
+		if !ok {
+			log.Println("[warn] all auth methods failed")
+			return echo.ErrUnauthorized
+		}
+		return next(c)
+	}
+}
+
+func (cfg *Config) CompatMiddlewareForAPI(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		req := c.Request()
+		contentType := req.Header.Get("Content-Type")
+		switch cfg.compatV1 {
+		case true:
+			// allows any content type
+		case false:
+			if req.Method == http.MethodPost && !strings.HasPrefix(contentType, "application/json") {
+				log.Printf("[error] invalid content type: %s for %s %s", contentType, req.Method, req.URL.Path)
+				return echo.ErrBadRequest
 			}
 		}
 		return next(c)

--- a/config_auth_test.go
+++ b/config_auth_test.go
@@ -209,7 +209,15 @@ func TestAuthMiddleware(t *testing.T) {
 					return c.String(http.StatusNotFound, "not found")
 				}
 			}
-			middleware := config.AuthMiddleware(handler)
+			mdForAPI := config.AuthMiddlewareForAPI(handler)
+			mdForWeb := config.AuthMiddlewareForWeb(handler)
+			middleware := func(c echo.Context) error {
+				if strings.HasPrefix(c.Request().URL.Path, "/api/") {
+					return mdForAPI(c)
+				} else {
+					return mdForWeb(c)
+				}
+			}
 			rec := httptest.NewRecorder()
 			c := e.NewContext(tc.Request(), rec)
 			err := middleware(c)

--- a/config_auth_test.go
+++ b/config_auth_test.go
@@ -199,11 +199,6 @@ func TestAuthMiddleware(t *testing.T) {
 				case "/api/list":
 					return c.JSON(http.StatusOK, []int{})
 				case "/launch":
-					log.Printf("[debug] origin: %s", c.Request().Header.Get("Origin"))
-					if err := config.ValidateOrigin(c.Request().Header.Get("Origin")); err != nil {
-						log.Printf("[debug] origin validation failed: %s", err)
-						return c.String(http.StatusBadRequest, err.Error())
-					}
 					return c.String(http.StatusOK, "launched")
 				default:
 					return c.String(http.StatusNotFound, "not found")

--- a/webapi.go
+++ b/webapi.go
@@ -57,21 +57,26 @@ func NewWebApi(cfg *Config, runner TaskRunner) *WebApi {
 	app.cfg = cfg
 
 	e := echo.New()
-	e.Use(cfg.AuthMiddleware)
 	e.Use(middleware.Logger())
-	e.GET("/", app.Top)
-	e.GET("/list", app.List)
-	e.GET("/launcher", app.Launcher)
-	e.POST("/launch", app.Launch)
-	e.POST("/terminate", app.Terminate)
-	e.GET("/trace/:taskid", app.Trace)
 
-	e.GET("/api/list", app.ApiList)
-	e.POST("/api/launch", app.ApiLaunch)
-	e.POST("/api/terminate", app.ApiTerminate)
-	e.POST("/api/purge", app.ApiPurge)
-	e.GET("/api/access", app.ApiAccess)
-	e.GET("/api/logs", app.ApiLogs)
+	web := e.Group("/")
+	web.Use(cfg.AuthMiddlewareForWeb)
+	web.GET("/", app.Top)
+	web.GET("/list", app.List)
+	web.GET("/launcher", app.Launcher)
+	web.POST("/launch", app.Launch)
+	web.POST("/terminate", app.Terminate)
+	web.GET("/trace/:taskid", app.Trace)
+
+	api := e.Group("/api")
+	api.Use(cfg.CompatMiddlewareForAPI)
+	api.Use(cfg.AuthMiddlewareForAPI)
+	api.GET("/list", app.ApiList)
+	api.POST("/launch", app.ApiLaunch)
+	api.POST("/terminate", app.ApiTerminate)
+	api.POST("/purge", app.ApiPurge)
+	api.GET("/access", app.ApiAccess)
+	api.GET("/logs", app.ApiLogs)
 	e.Renderer = &Template{
 		templates: template.Must(template.ParseGlob(cfg.HtmlDir + "/*")),
 	}


### PR DESCRIPTION
v2 API allows `content-type: application/json` only.

But for backward compatibility, flag `-compat-v1` allows `application/x-www-form-urlencoded` as v1.