### PR TITLE
v2 doesn't base64 encode a subdomain value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,13 +559,19 @@ parameters:
     required: false
 ```
 
-mirage-ecs also add `SUBDOMAIN` environment variable to the task. `SUBDOMAIN` is base64 encoded value of `subdomain` parameter.
+mirage-ecs also add `SUBDOMAIN` environment variable to the task.
 
-mirage-ecs tags the task with following keys and values.
+- (v0 and v1) `SUBDOMAIN` contains a base64 encoded value of `subdomain` parameter.
+- (v2) `SUBDOMAIN` contains a raw value of `subdomain` parameter.
+  `-compat-v1` cli flag enables v0,v1 behavior.
+
+mirage-ecs tags the ECS task with following keys and values.
 - `ManagedBy=mirage-ecs`
 - `Subdomain={base64 encoded subdomain}`
 - `branch={branch}`
 - `launched_by={launched_by}`
+
+The tag value of `Subdomain` is the base64 encoded value of the `subdomain` parameter always because some special characters(for example, `*`) are not allowed in tag values.
 
 #### `GET /api/logs`
 

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package mirageecs
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -605,5 +606,13 @@ func copyToFile(src io.Reader, dst string) (int64, error) {
 func (cfg *Config) ValidateOriginMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		return next(c)
+	}
+}
+
+func (cfg *Config) EncodeSubdomain(subdomain string) string {
+	if cfg.compatV1 {
+		return base64.URLEncoding.EncodeToString([]byte(subdomain))
+	} else {
+		return subdomain
 	}
 }

--- a/ecs_test.go
+++ b/ecs_test.go
@@ -1,6 +1,7 @@
 package mirageecs_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -21,9 +22,10 @@ func TestToECSKeyValuePairsAndTags(t *testing.T) {
 		expectedKVP  []types.KeyValuePair
 		expectedTags []types.Tag
 		expectedEnv  map[string]string
+		compatV1     bool
 	}{
 		{
-			name: "Basic Test",
+			name: "Basic Test v1",
 			taskParam: mirageecs.TaskParameter{
 				"Param1": "Value1",
 				"Param2": "Value2",
@@ -52,13 +54,50 @@ func TestToECSKeyValuePairsAndTags(t *testing.T) {
 				"ENV1":         "Value1",
 				"ENV2":         "Value2",
 			},
+			compatV1: true,
+		},
+		{
+			name: "Basic Test v2",
+			taskParam: mirageecs.TaskParameter{
+				"Param1": "Value1",
+				"Param2": "Value2",
+			},
+			configParams: mirageecs.Parameters{
+				&mirageecs.Parameter{Name: "Param1", Env: "ENV1"},
+				&mirageecs.Parameter{Name: "Param2", Env: "ENV2"},
+				&mirageecs.Parameter{Name: "Param3", Env: "ENV3"},
+			},
+			subdomain: "testsubdomain",
+			expectedKVP: []types.KeyValuePair{
+				{Name: aws.String("SUBDOMAIN"), Value: aws.String("testsubdomain")},
+				{Name: aws.String("SUBDOMAINRAW"), Value: aws.String("testsubdomain")},
+				{Name: aws.String("ENV1"), Value: aws.String("Value1")},
+				{Name: aws.String("ENV2"), Value: aws.String("Value2")},
+			},
+			expectedTags: []types.Tag{
+				{Key: aws.String("Subdomain"), Value: aws.String("dGVzdHN1YmRvbWFpbg==")},
+				{Key: aws.String("ManagedBy"), Value: aws.String(mirageecs.TagValueMirage)},
+				{Key: aws.String("Param1"), Value: aws.String("Value1")},
+				{Key: aws.String("Param2"), Value: aws.String("Value2")},
+			},
+			expectedEnv: map[string]string{
+				"SUBDOMAIN":    "testsubdomain",
+				"SUBDOMAINRAW": "testsubdomain",
+				"ENV1":         "Value1",
+				"ENV2":         "Value2",
+			},
+			compatV1: false,
 		},
 	}
 
 	opt := cmpopts.IgnoreUnexported(types.KeyValuePair{}, types.Tag{})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kvpResult := tt.taskParam.ToECSKeyValuePairs(tt.subdomain, tt.configParams)
+			cfg, _ := mirageecs.NewConfig(context.Background(), &mirageecs.ConfigParams{
+				LocalMode: true,
+				CompatV1:  tt.compatV1,
+			})
+			kvpResult := tt.taskParam.ToECSKeyValuePairs(tt.subdomain, tt.configParams, cfg.EncodeSubdomain)
 			if diff := cmp.Diff(kvpResult, tt.expectedKVP, opt); diff != "" {
 				t.Errorf("Mismatch in KeyValuePairs (-got +want):\n%s", diff)
 			}
@@ -66,7 +105,7 @@ func TestToECSKeyValuePairsAndTags(t *testing.T) {
 			if diff := cmp.Diff(tagsResult, tt.expectedTags, opt); diff != "" {
 				t.Errorf("Mismatch in Tags (-got +want):\n%s", diff)
 			}
-			envResult := tt.taskParam.ToEnv(tt.subdomain, tt.configParams)
+			envResult := tt.taskParam.ToEnv(tt.subdomain, tt.configParams, cfg.EncodeSubdomain)
 			if diff := cmp.Diff(envResult, tt.expectedEnv, opt); diff != "" {
 				t.Errorf("Mismatch in Env (-got +want):\n%s", diff)
 			}

--- a/local.go
+++ b/local.go
@@ -60,7 +60,7 @@ func (e *LocalTaskRunner) Launch(ctx context.Context, subdomain string, option T
 		}
 	}
 	id := generateRandomHexID(32)
-	env := option.ToEnv(subdomain, e.cfg.Parameter)
+	env := option.ToEnv(subdomain, e.cfg.Parameter, e.cfg.EncodeSubdomain)
 	slog.Info(f("Launching a new mock task: subdomain=%s, taskdef=%s, id=%s", subdomain, taskdefs[0], id))
 	contents := fmt.Sprintf("Hello, Mirage! subdomain: %s\n%#v", subdomain, env)
 	port, stopServerFunc := runMockServer(contents)


### PR DESCRIPTION
From v2, the SUBDOMAIN environment variable has a raw value. However, the tag value of the ECS task needs to be encoded because some special characters are not allowed.

Add Config.EncodeSubdomain() to encode the value.