### PR TITLE
set ldflags to embed Version and buildDate

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags: -s -w -X main.Version={{.Version}} -X main.buildDate={{.Date}}
 archives:
   - files:
       - config_sample.yml


### PR DESCRIPTION
v2 doesn't show the Version and buildDate.

```console
$ mirage-ecs -version
mirage-ecs  ()
```