### PR TITLE
Fix: panic when config.ecs.launch_type is nil

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -217,12 +217,15 @@ func (e *ECS) launchTask(ctx context.Context, subdomain string, taskdef string, 
 		Cluster:                  aws.String(cfg.ECS.Cluster),
 		TaskDefinition:           aws.String(taskdef),
 		NetworkConfiguration:     cfg.ECS.networkConfiguration,
-		LaunchType:               types.LaunchType(*cfg.ECS.LaunchType),
 		Overrides:                ov,
 		Count:                    aws.Int32(1),
 		Tags:                     tags,
 		EnableExecuteCommand:     aws.ToBool(cfg.ECS.EnableExecuteCommand),
 	}
+	if lt := cfg.ECS.LaunchType; lt != nil {
+		runtaskInput.LaunchType = types.LaunchType(*lt)
+	}
+
 	slog.Debug(f("RunTaskInput: %v", runtaskInput))
 	out, err := e.svc.RunTask(ctx, runtaskInput)
 	if err != nil {


### PR DESCRIPTION
Fix panic raised when `launch_type` is nil (not defined in yaml).

```
2024-03-29T05:47:33.811Z [info] [ecs.go:190] launching task subdomain:com taskdef:dev-app
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xcc36f5]
goroutine 161 [running]:
github.com/acidlemon/mirage-ecs/v2.(*ECS).launchTask(0xc0002e71a0, {0xfd2290, 0xc00012cc40}, {0xc0003b006a, 0x3}, {0xc0003b0084, 0x7}, 0xc000462240?)
	/stash/src/github.com/acidlemon/mirage-ecs/ecs.go:220 +0x735
github.com/acidlemon/mirage-ecs/v2.(*ECS).Launch.func1()
	/stash/src/github.com/acidlemon/mirage-ecs/ecs.go:259 +0x33
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/stash/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 145
	/stash/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:72 +0x96
```