### PR TITLE
Fix: transport breaks large contents by setting a timeout.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -2,4 +2,5 @@ package mirageecs
 
 var (
 	ValidateSubdomain = validateSubdomain
+	NewHTTPTransport  = newHTTPTransport
 )


### PR DESCRIPTION
refs #69

Transport was calling a cancel() func before completing the transfer response body. The cancel stops the transfer.

Set timeouts into http.Transport instead of using context.WithCacel.