### PR TITLE
Fix panic when fields of Failures are nil

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -227,8 +227,16 @@ func (e *ECS) launchTask(ctx context.Context, subdomain string, taskdef string, 
 	}
 	if len(out.Failures) > 0 {
 		f := out.Failures[0]
+		reason := "(unknown)"
+		if f.Reason != nil {
+			reason = *f.Reason
+		}
+		arn := "(unknown)"
+		if f.Arn != nil {
+			arn = *f.Arn
+		}
 		return fmt.Errorf(
-			"run task failed. reason:%s arn:%s", *f.Reason, *f.Arn,
+			"run task failed. reason:%s arn:%s", reason, arn,
 		)
 	}
 	task := out.Tasks[0]


### PR DESCRIPTION
`Reason` and `Arn` which are referenced when RunTask failed can be nil.
This fixes panic raised when these fields are nil.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc191d1]
goroutine 513097 [running]:
github.com/acidlemon/mirage-ecs/v2.(*ECS).launchTask(0xc0000a19b0, {0xf01750, 0xc0000bc230}, {0xc00182b500, 0x21}, {0xc001372660, 0x52}, 0xc00045dc20?)
	/stash/src/github.com/acidlemon/mirage-ecs/ecs.go:231 +0x971
github.com/acidlemon/mirage-ecs/v2.(*ECS).Launch.func1()
	/stash/src/github.com/acidlemon/mirage-ecs/ecs.go:256 +0x33
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/stash/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 416582
```