### PR TITLE
go version maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.22"
-          - "1.23"
           - "1.24"
+          - "1.25"
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=builder /stash/mirage-ecs /opt/mirage/
 COPY --from=builder /stash/example-config.yml /opt/mirage/
 COPY --from=builder /stash/html/* /opt/mirage/html/
 WORKDIR /opt/mirage
-ENV MIRAGE_LOG_LEVEL info
-ENV MIRAGE_CONF ""
+ENV MIRAGE_LOG_LEVEL=info
+ENV MIRAGE_CONF=""
 RUN /opt/mirage/mirage-ecs -version
 ENTRYPOINT ["/opt/mirage/mirage-ecs"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.25 AS builder
 
 ADD . /stash/src/github.com/acidlemon/mirage-ecs
 WORKDIR /stash/src/github.com/acidlemon/mirage-ecs


### PR DESCRIPTION
- update builder version from 1.23 to 1.25
- fix ENV line format
- update go version of matrix tests