### PR TITLE
add exclude_containers to link config for filtering Route53 record registration

### DIFF
--- a/config.go
+++ b/config.go
@@ -157,6 +157,7 @@ type Host struct {
 type Link struct {
 	HostedZoneID           string   `yaml:"hosted_zone_id"`
 	DefaultTaskDefinitions []string `yaml:"default_task_definitions"`
+	ExcludeContainers      []string `yaml:"exclude_containers"`
 }
 
 type Listen struct {

--- a/config_test.go
+++ b/config_test.go
@@ -63,6 +63,9 @@ link:
   default_task_definitions:
     - test-task-definition
     - test-task-definition-link
+  exclude_containers:
+    - dd-agent
+    - log-router
 `
 
 	if err := ioutil.WriteFile(f.Name(), []byte(data), 0644); err != nil {
@@ -123,5 +126,11 @@ link:
 	}
 	if cfg.Link.DefaultTaskDefinitions[1] != "test-task-definition-link" {
 		t.Error("could not parse link default task definitions")
+	}
+	if cfg.Link.ExcludeContainers[0] != "dd-agent" {
+		t.Error("could not parse link exclude containers")
+	}
+	if cfg.Link.ExcludeContainers[1] != "log-router" {
+		t.Error("could not parse link exclude containers")
 	}
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,7 @@
 package mirageecs
 
 var (
-	ValidateSubdomain = validateSubdomain
-	NewHTTPTransport  = newHTTPTransport
+	ValidateSubdomain        = validateSubdomain
+	NewHTTPTransport         = newHTTPTransport
+	LinkShouldRegisterRecord = (*Link).shouldRegisterRecord
 )

--- a/export_test.go
+++ b/export_test.go
@@ -3,5 +3,5 @@ package mirageecs
 var (
 	ValidateSubdomain        = validateSubdomain
 	NewHTTPTransport         = newHTTPTransport
-	LinkShouldRegisterRecord = (*Link).shouldRegisterRecord
+	LinkIsExcluded = (*Link).isExcluded
 )

--- a/link.go
+++ b/link.go
@@ -1,0 +1,15 @@
+package mirageecs
+
+import "path"
+
+func (l *Link) shouldRegisterRecord(containerName string) bool {
+	if l.HostedZoneID == "" {
+		return false
+	}
+	for _, excluded := range l.ExcludeContainers {
+		if m, _ := path.Match(excluded, containerName); m {
+			return false
+		}
+	}
+	return true
+}

--- a/link.go
+++ b/link.go
@@ -2,14 +2,14 @@ package mirageecs
 
 import "path"
 
-func (l *Link) shouldRegisterRecord(containerName string) bool {
+func (l *Link) isExcluded(containerName string) bool {
 	if l.HostedZoneID == "" {
-		return false
+		return true
 	}
 	for _, excluded := range l.ExcludeContainers {
 		if m, _ := path.Match(excluded, containerName); m {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }

--- a/link_test.go
+++ b/link_test.go
@@ -6,11 +6,11 @@ import (
 	mirageecs "github.com/acidlemon/mirage-ecs/v2"
 )
 
-func TestLinkShouldRegisterRecord(t *testing.T) {
-	t.Run("returns false when hosted_zone_id is not set", func(t *testing.T) {
+func TestLinkIsExcluded(t *testing.T) {
+	t.Run("returns true when hosted_zone_id is not set", func(t *testing.T) {
 		link := &mirageecs.Link{}
-		if mirageecs.LinkShouldRegisterRecord(link, "httpd") {
-			t.Errorf("should not register record when hosted_zone_id is not set")
+		if !mirageecs.LinkIsExcluded(link, "httpd") {
+			t.Errorf("should be excluded when hosted_zone_id is not set")
 		}
 	})
 
@@ -23,20 +23,20 @@ func TestLinkShouldRegisterRecord(t *testing.T) {
 			name     string
 			expected bool
 		}{
-			// should register
-			{"httpd", true},
-			{"app", true},
-			{"sidecar", true}, // "sidecar-*" requires a suffix, so "sidecar" itself is not excluded
+			// not excluded
+			{"httpd", false},
+			{"app", false},
+			{"sidecar", false}, // "sidecar-*" requires a suffix, so "sidecar" itself is not excluded
 			// excluded by exact match
-			{"log-router", false},
-			{"dd-agent", false},
+			{"log-router", true},
+			{"dd-agent", true},
 			// excluded by wildcard
-			{"sidecar-agent", false},
-			{"sidecar-metrics", false},
+			{"sidecar-agent", true},
+			{"sidecar-metrics", true},
 		}
 		for _, c := range cases {
-			if got := mirageecs.LinkShouldRegisterRecord(link, c.name); got != c.expected {
-				t.Errorf("shouldRegisterRecord(%q) = %v, want %v", c.name, got, c.expected)
+			if got := mirageecs.LinkIsExcluded(link, c.name); got != c.expected {
+				t.Errorf("isExcluded(%q) = %v, want %v", c.name, got, c.expected)
 			}
 		}
 	})

--- a/link_test.go
+++ b/link_test.go
@@ -1,0 +1,43 @@
+package mirageecs_test
+
+import (
+	"testing"
+
+	mirageecs "github.com/acidlemon/mirage-ecs/v2"
+)
+
+func TestLinkShouldRegisterRecord(t *testing.T) {
+	t.Run("returns false when hosted_zone_id is not set", func(t *testing.T) {
+		link := &mirageecs.Link{}
+		if mirageecs.LinkShouldRegisterRecord(link, "httpd") {
+			t.Errorf("should not register record when hosted_zone_id is not set")
+		}
+	})
+
+	t.Run("filters by exclude_containers", func(t *testing.T) {
+		link := &mirageecs.Link{
+			HostedZoneID:      "Z00000000000000000000",
+			ExcludeContainers: []string{"log-router", "dd-agent", "sidecar-*"},
+		}
+		cases := []struct {
+			name     string
+			expected bool
+		}{
+			// should register
+			{"httpd", true},
+			{"app", true},
+			{"sidecar", true}, // "sidecar-*" requires a suffix, so "sidecar" itself is not excluded
+			// excluded by exact match
+			{"log-router", false},
+			{"dd-agent", false},
+			// excluded by wildcard
+			{"sidecar-agent", false},
+			{"sidecar-metrics", false},
+		}
+		for _, c := range cases {
+			if got := mirageecs.LinkShouldRegisterRecord(link, c.name); got != c.expected {
+				t.Errorf("shouldRegisterRecord(%q) = %v, want %v", c.name, got, c.expected)
+			}
+		}
+	})
+}

--- a/mirage.go
+++ b/mirage.go
@@ -216,7 +216,7 @@ SYNC:
 				available[info.SubDomain] = true
 				for name, port := range info.PortMap {
 					rp.AddSubdomain(info.SubDomain, info.IPAddress, port)
-					if app.Config.Link.shouldRegisterRecord(name) {
+					if !app.Config.Link.isExcluded(name) {
 						r53.Add(name+"."+info.SubDomain, info.IPAddress)
 					}
 				}
@@ -231,7 +231,9 @@ SYNC:
 		for _, info := range stopped {
 			slog.Debug(f("stopped task %s", info.ID))
 			for name := range info.PortMap {
-				r53.Delete(name+"."+info.SubDomain, info.IPAddress)
+				if !app.Config.Link.isExcluded(name) {
+					r53.Delete(name+"."+info.SubDomain, info.IPAddress)
+				}
 			}
 		}
 

--- a/mirage.go
+++ b/mirage.go
@@ -216,7 +216,9 @@ SYNC:
 				available[info.SubDomain] = true
 				for name, port := range info.PortMap {
 					rp.AddSubdomain(info.SubDomain, info.IPAddress, port)
-					r53.Add(name+"."+info.SubDomain, info.IPAddress)
+					if app.Config.Link.shouldRegisterRecord(name) {
+						r53.Add(name+"."+info.SubDomain, info.IPAddress)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds `exclude_containers` field to the `link` config section.

It is common to launch ECS tasks with sidecar containers such as `log-router` or monitoring agents
alongside the main container. When these sidecars have port mappings, mirage-ecs was registering
Route53 records for all of them unconditionally. Since sidecars don't need their own DNS records,
this results in an unnecessarily large number of Route53 records — especially when running many
tasks at once.

With this change, you can exclude specific containers from Route53 record registration by listing
their names in `link.exclude_containers`. Wildcard patterns (`*`, `?`) are also supported.

The default behavior (registering records for all containers) is preserved.

----

`exclude_containers` can be configured in the `link` section.

```yaml
link:
  hosted_zone_id: ZZZZZZZZZZZZZZ
  exclude_containers:
    - dd-agent        # exact match
    - log-router
    - sidecar-*       # wildcard: matches sidecar-agent, sidecar-metrics, etc.
```