### PR TITLE
Add status query parameter to GET /api/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,11 @@ GET APIs only accept URL query parameters.
 
 ### `GET /api/list`
 
-`/api/list` returns list of running tasks.
+`/api/list` returns list of tasks.
+
+| Query Parameter | Description |
+| --- | --- |
+| `status` | Filter by task status. `running` (default), `stopped`, or `all` |
 
 ```json
 {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -34,6 +34,107 @@ var e2eRequestsJSON = map[string]string{
 	"/api/terminate": `{"subdomain":"mytask"}`,
 }
 
+func TestApiListStatusFilter(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := mirageecs.NewConfig(ctx, &mirageecs.ConfigParams{
+		LocalMode: true,
+		Domain:    "localtest.me",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := mirageecs.New(context.Background(), cfg)
+	ts := httptest.NewServer(m.WebApi)
+	defer ts.Close()
+	client := ts.Client()
+
+	apiList := func(status string) mirageecs.APIListResponse {
+		u := ts.URL + "/api/list"
+		if status != "" {
+			u += "?status=" + status
+		}
+		res, err := client.Get(u)
+		if err != nil {
+			t.Fatalf("GET %s: %s", u, err)
+		}
+		defer res.Body.Close()
+		if res.StatusCode != 200 {
+			t.Fatalf("status code should be 200: %d", res.StatusCode)
+		}
+		var r mirageecs.APIListResponse
+		json.NewDecoder(res.Body).Decode(&r)
+		return r
+	}
+
+	launch := func(subdomain string) {
+		body := `{"subdomain":"` + subdomain + `","taskdef":["dummy"],"branch":"main"}`
+		req, _ := http.NewRequest("POST", ts.URL+"/api/launch", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("launch %s: %s", subdomain, err)
+		}
+		defer res.Body.Close()
+		if res.StatusCode != 200 {
+			t.Fatalf("launch status code should be 200: %d", res.StatusCode)
+		}
+	}
+
+	terminate := func(subdomain string) {
+		body := `{"subdomain":"` + subdomain + `"}`
+		req, _ := http.NewRequest("POST", ts.URL+"/api/terminate", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("terminate %s: %s", subdomain, err)
+		}
+		defer res.Body.Close()
+		if res.StatusCode != 200 {
+			t.Fatalf("terminate status code should be 200: %d", res.StatusCode)
+		}
+	}
+
+	// Launch task-a and task-b, then terminate task-b.
+	// Expected state: task-a=RUNNING, task-b=STOPPED
+	launch("task-a")
+	launch("task-b")
+	terminate("task-b")
+
+	t.Run("default returns only running", func(t *testing.T) {
+		r := apiList("")
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 running task, got %d", len(r.Result))
+		}
+		if len(r.Result) > 0 && r.Result[0].SubDomain != "task-a" {
+			t.Errorf("expected task-a, got %s", r.Result[0].SubDomain)
+		}
+	})
+
+	t.Run("status=running returns only running", func(t *testing.T) {
+		r := apiList("running")
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 running task, got %d", len(r.Result))
+		}
+	})
+
+	t.Run("status=stopped returns only stopped", func(t *testing.T) {
+		r := apiList("stopped")
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 stopped task, got %d", len(r.Result))
+		}
+		if len(r.Result) > 0 && r.Result[0].SubDomain != "task-b" {
+			t.Errorf("expected task-b, got %s", r.Result[0].SubDomain)
+		}
+	})
+
+	t.Run("status=all returns both running and stopped", func(t *testing.T) {
+		r := apiList("all")
+		if len(r.Result) != 2 {
+			t.Errorf("expected 2 tasks (1 running + 1 stopped), got %d", len(r.Result))
+		}
+	})
+}
+
 func TestE2EAPI(t *testing.T) {
 	t.Run("form v1", func(t *testing.T) {
 		testE2EAPI(t, e2eRequestsForm, "application/x-www-form-urlencoded", true)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -34,107 +34,6 @@ var e2eRequestsJSON = map[string]string{
 	"/api/terminate": `{"subdomain":"mytask"}`,
 }
 
-func TestApiListStatusFilter(t *testing.T) {
-	ctx := context.Background()
-	cfg, err := mirageecs.NewConfig(ctx, &mirageecs.ConfigParams{
-		LocalMode: true,
-		Domain:    "localtest.me",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	m := mirageecs.New(context.Background(), cfg)
-	ts := httptest.NewServer(m.WebApi)
-	defer ts.Close()
-	client := ts.Client()
-
-	apiList := func(status string) mirageecs.APIListResponse {
-		u := ts.URL + "/api/list"
-		if status != "" {
-			u += "?status=" + status
-		}
-		res, err := client.Get(u)
-		if err != nil {
-			t.Fatalf("GET %s: %s", u, err)
-		}
-		defer res.Body.Close()
-		if res.StatusCode != 200 {
-			t.Fatalf("status code should be 200: %d", res.StatusCode)
-		}
-		var r mirageecs.APIListResponse
-		json.NewDecoder(res.Body).Decode(&r)
-		return r
-	}
-
-	launch := func(subdomain string) {
-		body := `{"subdomain":"` + subdomain + `","taskdef":["dummy"],"branch":"main"}`
-		req, _ := http.NewRequest("POST", ts.URL+"/api/launch", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		res, err := client.Do(req)
-		if err != nil {
-			t.Fatalf("launch %s: %s", subdomain, err)
-		}
-		defer res.Body.Close()
-		if res.StatusCode != 200 {
-			t.Fatalf("launch status code should be 200: %d", res.StatusCode)
-		}
-	}
-
-	terminate := func(subdomain string) {
-		body := `{"subdomain":"` + subdomain + `"}`
-		req, _ := http.NewRequest("POST", ts.URL+"/api/terminate", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		res, err := client.Do(req)
-		if err != nil {
-			t.Fatalf("terminate %s: %s", subdomain, err)
-		}
-		defer res.Body.Close()
-		if res.StatusCode != 200 {
-			t.Fatalf("terminate status code should be 200: %d", res.StatusCode)
-		}
-	}
-
-	// Launch task-a and task-b, then terminate task-b.
-	// Expected state: task-a=RUNNING, task-b=STOPPED
-	launch("task-a")
-	launch("task-b")
-	terminate("task-b")
-
-	t.Run("default returns only running", func(t *testing.T) {
-		r := apiList("")
-		if len(r.Result) != 1 {
-			t.Errorf("expected 1 running task, got %d", len(r.Result))
-		}
-		if len(r.Result) > 0 && r.Result[0].SubDomain != "task-a" {
-			t.Errorf("expected task-a, got %s", r.Result[0].SubDomain)
-		}
-	})
-
-	t.Run("status=running returns only running", func(t *testing.T) {
-		r := apiList("running")
-		if len(r.Result) != 1 {
-			t.Errorf("expected 1 running task, got %d", len(r.Result))
-		}
-	})
-
-	t.Run("status=stopped returns only stopped", func(t *testing.T) {
-		r := apiList("stopped")
-		if len(r.Result) != 1 {
-			t.Errorf("expected 1 stopped task, got %d", len(r.Result))
-		}
-		if len(r.Result) > 0 && r.Result[0].SubDomain != "task-b" {
-			t.Errorf("expected task-b, got %s", r.Result[0].SubDomain)
-		}
-	})
-
-	t.Run("status=all returns both running and stopped", func(t *testing.T) {
-		r := apiList("all")
-		if len(r.Result) != 2 {
-			t.Errorf("expected 2 tasks (1 running + 1 stopped), got %d", len(r.Result))
-		}
-	})
-}
-
 func TestE2EAPI(t *testing.T) {
 	t.Run("form v1", func(t *testing.T) {
 		testE2EAPI(t, e2eRequestsForm, "application/x-www-form-urlencoded", true)
@@ -231,6 +130,45 @@ func testE2EAPI(t *testing.T, reqs map[string]string, contentType string, compat
 		}
 	})
 
+	t.Run("/api/list?status=running after launched", func(t *testing.T) {
+		res, err := client.Get(ts.URL + "/api/list?status=running")
+		if err != nil {
+			t.Error(err)
+		}
+		defer res.Body.Close()
+		var r mirageecs.APIListResponse
+		json.NewDecoder(res.Body).Decode(&r)
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 running task, got %d", len(r.Result))
+		}
+	})
+
+	t.Run("/api/list?status=stopped after launched", func(t *testing.T) {
+		res, err := client.Get(ts.URL + "/api/list?status=stopped")
+		if err != nil {
+			t.Error(err)
+		}
+		defer res.Body.Close()
+		var r mirageecs.APIListResponse
+		json.NewDecoder(res.Body).Decode(&r)
+		if len(r.Result) != 0 {
+			t.Errorf("expected 0 stopped tasks, got %d", len(r.Result))
+		}
+	})
+
+	t.Run("/api/list?status=all after launched", func(t *testing.T) {
+		res, err := client.Get(ts.URL + "/api/list?status=all")
+		if err != nil {
+			t.Error(err)
+		}
+		defer res.Body.Close()
+		var r mirageecs.APIListResponse
+		json.NewDecoder(res.Body).Decode(&r)
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 task, got %d", len(r.Result))
+		}
+	})
+
 	t.Run("/api/access", func(t *testing.T) {
 		res, err := client.Get(ts.URL + "/api/access?subdomain=mytask&duration=300")
 		if err != nil {
@@ -305,6 +243,35 @@ func testE2EAPI(t *testing.T, reqs map[string]string, contentType string, compat
 		json.NewDecoder(res.Body).Decode(&r)
 		if len(r.Result) != 0 {
 			t.Errorf("result should be empty %#v", r)
+		}
+	})
+
+	t.Run("/api/list?status=stopped after terminate", func(t *testing.T) {
+		res, err := client.Get(ts.URL + "/api/list?status=stopped")
+		if err != nil {
+			t.Error(err)
+		}
+		defer res.Body.Close()
+		var r mirageecs.APIListResponse
+		json.NewDecoder(res.Body).Decode(&r)
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 stopped task, got %d", len(r.Result))
+		}
+		if len(r.Result) > 0 && r.Result[0].SubDomain != "mytask" {
+			t.Errorf("subdomain should be mytask, got %s", r.Result[0].SubDomain)
+		}
+	})
+
+	t.Run("/api/list?status=all after terminate", func(t *testing.T) {
+		res, err := client.Get(ts.URL + "/api/list?status=all")
+		if err != nil {
+			t.Error(err)
+		}
+		defer res.Body.Close()
+		var r mirageecs.APIListResponse
+		json.NewDecoder(res.Body).Decode(&r)
+		if len(r.Result) != 1 {
+			t.Errorf("expected 1 task, got %d", len(r.Result))
 		}
 	})
 

--- a/webapi.go
+++ b/webapi.go
@@ -165,9 +165,33 @@ func (api *WebApi) Trace(c echo.Context) error {
 }
 
 func (api *WebApi) ApiList(c echo.Context) error {
-	info, err := api.runner.List(c.Request().Context(), statusRunning)
-	if err != nil {
-		return c.JSON(500, APIListResponse{})
+	ctx := c.Request().Context()
+	status := c.QueryParam("status")
+
+	var info []*Information
+	switch status {
+	case "stopped":
+		var err error
+		info, err = api.runner.List(ctx, statusStopped)
+		if err != nil {
+			return c.JSON(500, APIListResponse{})
+		}
+	case "all":
+		running, err := api.runner.List(ctx, statusRunning)
+		if err != nil {
+			return c.JSON(500, APIListResponse{})
+		}
+		stopped, err := api.runner.List(ctx, statusStopped)
+		if err != nil {
+			return c.JSON(500, APIListResponse{})
+		}
+		info = append(running, stopped...)
+	default:
+		var err error
+		info, err = api.runner.List(ctx, statusRunning)
+		if err != nil {
+			return c.JSON(500, APIListResponse{})
+		}
 	}
 	return c.JSON(200, APIListResponse{Result: info})
 }


### PR DESCRIPTION
## Summary

Add a `status` query parameter to `GET /api/list` so that it can return the same task information as the HTML `/list` endpoint.

| Parameter value | Behavior |
|---|---|
| omitted / `running` | Running tasks only (existing behavior) |
| `stopped` | Stopped tasks only |
| `all` | Both running and stopped tasks |

## Background

The HTML `/list` endpoint shows both running and stopped tasks, but `/api/list` only returned running tasks. This change brings the API to parity with the HTML endpoint while maintaining backward compatibility for existing clients.